### PR TITLE
Cascade delete user container states when deleting containers

### DIFF
--- a/mindstack_app/models.py
+++ b/mindstack_app/models.py
@@ -124,7 +124,11 @@ class UserContainerState(db.Model):
     last_accessed = db.Column(db.DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
 
     # Mối quan hệ với LearningContainer
-    container = db.relationship('LearningContainer', backref='user_states', lazy=True)
+    container = db.relationship(
+        'LearningContainer',
+        backref=db.backref('user_states', cascade='all, delete-orphan'),
+        lazy=True,
+    )
 
     __table_args__ = (db.UniqueConstraint('user_id', 'container_id', name='_user_container_uc'),)
 


### PR DESCRIPTION
## Summary
- update the UserContainerState.container relationship to use a backref with delete-orphan cascading so related records are removed when a LearningContainer is deleted

## Testing
- python - <<'PY'
from mindstack_app import app
from mindstack_app.models import db, User, LearningContainer, UserContainerState
from sqlalchemy.exc import IntegrityError

username = 'cascade_tester'
email = 'cascade_tester@example.com'

with app.app_context():
    # cleanup existing test data if rerun
    user = User.query.filter_by(username=username).first()
    if user:
        UserContainerState.query.filter_by(user_id=user.user_id).delete()
        LearningContainer.query.filter_by(creator_user_id=user.user_id).delete()
        db.session.delete(user)
        db.session.commit()

    user = User(username=username, email=email)
    user.set_password('password123')
    db.session.add(user)
    db.session.commit()

    container = LearningContainer(
        creator_user_id=user.user_id,
        container_type='QUIZ_SET',
        title='Cascade Test Quiz',
        description='Test deletion cascade.'
    )
    db.session.add(container)
    db.session.commit()

    state = UserContainerState(user_id=user.user_id, container_id=container.container_id)
    db.session.add(state)
    db.session.commit()

    print('Before deletion:', UserContainerState.query.count(), LearningContainer.query.filter_by(title='Cascade Test Quiz').count())

    try:
        db.session.delete(container)
        db.session.commit()
        print('Deletion succeeded.')
    except IntegrityError as e:
        db.session.rollback()
        print('IntegrityError:', e)

    print('After deletion:', UserContainerState.query.filter_by(user_id=user.user_id).count(), LearningContainer.query.filter_by(title='Cascade Test Quiz').count())

    # Clean up user
    db.session.delete(user)
    db.session.commit()
PY

------
https://chatgpt.com/codex/tasks/task_e_68d00f4444e8832692a42eb91dfaf043