### PR TITLE
Allow profile updates to include email

### DIFF
--- a/mindstack_app/modules/user_profile/routes.py
+++ b/mindstack_app/modules/user_profile/routes.py
@@ -36,8 +36,9 @@ def edit_profile():
     
     if form.validate_on_submit():
         user.username = form.username.data
+        user.email = form.email.data
         # Không cho phép người dùng tự đổi user_role của mình
-        # user.user_role = form.user_role.data 
+        # user.user_role = form.user_role.data
         
         # Chỉ cập nhật mật khẩu nếu người dùng nhập mật khẩu mới
         if form.password.data:
@@ -54,8 +55,8 @@ def edit_profile():
     # Nếu là GET request, điền dữ liệu người dùng vào form
     elif request.method == 'GET':
         # Ẩn trường user_role khi người dùng tự sửa profile
-        # form.user_role.data = user.user_role 
-        pass
+        # form.user_role.data = user.user_role
+        form.email.data = user.email
 
     return render_template('edit_profile.html', form=form, title='Sửa Profile', user=user)
 

--- a/mindstack_app/modules/user_profile/templates/edit_profile.html
+++ b/mindstack_app/modules/user_profile/templates/edit_profile.html
@@ -19,7 +19,17 @@
                         </div>
                     {% endif %}
                 </div>
-                
+
+                <div>
+                    {{ form.email.label(class="block text-sm font-medium text-gray-700") }}
+                    {{ form.email(class="mt-1 block w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500", placeholder="Email") }}
+                    {% if form.email.errors %}
+                        <div class="text-red-500 text-xs mt-1">
+                            {% for error in form.email.errors %}<p>{{ error }}</p>{% endfor %}
+                        </div>
+                    {% endif %}
+                </div>
+
                 <div>
                     {{ form.password.label(class="block text-sm font-medium text-gray-700") }}
                     {{ form.password(class="mt-1 block w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500", placeholder="Mật khẩu (để trống nếu không muốn đổi)") }}


### PR DESCRIPTION
## Summary
- update the user profile edit route to persist the submitted email address and preload it during GET requests
- render the email field and validation feedback on the edit profile template while keeping the role selector hidden

## Testing
- python - <<'PY' ... (profile update submission test)
- python - <<'PY' ... (role preservation test)


------
https://chatgpt.com/codex/tasks/task_e_68d0144a15e08326a2f16b285b6da609