### PR TITLE
Ensure admin audio cache tasks close loops safely

### DIFF
--- a/mindstack_app/modules/admin/routes.py
+++ b/mindstack_app/modules/admin/routes.py
@@ -91,13 +91,9 @@ def start_task(task_id):
         
         # Chạy tác vụ trong một thread hoặc process riêng
         if task.task_name == 'generate_audio_cache':
-            loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
-            loop.run_until_complete(audio_service.generate_cache_for_all_cards(task))
+            asyncio.run(audio_service.generate_cache_for_all_cards(task))
         elif task.task_name == 'clean_audio_cache':
-            loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
-            loop.run_until_complete(audio_service.clean_orphan_audio_cache(task))
+            audio_service.clean_orphan_audio_cache(task)
             
     return jsonify({'success': True})
 


### PR DESCRIPTION
## Summary
- run audio cache generation via `asyncio.run` so the loop is created and cleaned automatically
- execute the audio cache cleaning task synchronously to avoid unnecessary event loop usage

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0154659a08326bc0dce403d63331a