### PR TITLE
Add role constants and update registration roles

### DIFF
--- a/mindstack_app/__init__.py
+++ b/mindstack_app/__init__.py
@@ -97,7 +97,7 @@ def create_app(config_class=Config):
 
         admin_user = User.query.filter_by(username='admin').first()
         if admin_user is None:
-            admin = User(username='admin', email='admin@example.com', user_role='admin')
+            admin = User(username='admin', email='admin@example.com', user_role=User.ROLE_ADMIN)
             admin.set_password('admin')
             db.session.add(admin)
             db.session.commit()

--- a/mindstack_app/models.py
+++ b/mindstack_app/models.py
@@ -69,13 +69,28 @@ class LearningItem(db.Model):
 class User(UserMixin, db.Model):
     """
     Mô tả: Model đại diện cho người dùng của ứng dụng.
+
+    Các hằng số ROLE_* giúp quản lý tập trung các quyền người dùng trong toàn bộ
+    ứng dụng và tránh việc hard-code chuỗi ở nhiều nơi.
     """
     __tablename__ = 'users'
+    ROLE_ADMIN = 'admin'
+    ROLE_USER = 'user'
+    ROLE_FREE = 'free'
+    ROLE_ANONYMOUS = 'anonymous'
+    ROLE_LABELS = {
+        ROLE_ADMIN: 'Quản trị viên',
+        ROLE_USER: 'Người dùng chuẩn',
+        ROLE_FREE: 'Tài khoản miễn phí',
+        ROLE_ANONYMOUS: 'Ẩn danh',
+    }
+
     user_id = db.Column(db.Integer, primary_key=True)
     username = db.Column(db.String(80), unique=True, nullable=False)
     email = db.Column(db.String(120), unique=True, nullable=False)
     password_hash = db.Column(db.String(256), nullable=False)
-    user_role = db.Column(db.String(50), default='user', nullable=False) # 'user', 'admin'
+    # user_role sử dụng các hằng ROLE_* ở trên (ví dụ: ROLE_FREE, ROLE_USER, ROLE_ADMIN, ROLE_ANONYMOUS)
+    user_role = db.Column(db.String(50), default=ROLE_FREE, nullable=False)
     total_score = db.Column(db.Integer, default=0)
     last_seen = db.Column(db.DateTime(timezone=True))
 

--- a/mindstack_app/modules/admin/routes.py
+++ b/mindstack_app/modules/admin/routes.py
@@ -23,7 +23,7 @@ from . import admin_bp # Vẫn cần dòng này để các decorator như @admin
 @admin_bp.before_request 
 @login_required 
 def admin_required():
-    if not current_user.is_authenticated or current_user.user_role != 'admin':
+    if not current_user.is_authenticated or current_user.user_role != User.ROLE_ADMIN:
         flash('Bạn không có quyền truy cập khu vực quản trị.', 'danger')
         abort(403) 
 

--- a/mindstack_app/modules/admin/user_management/user_routes.py
+++ b/mindstack_app/modules/admin/user_management/user_routes.py
@@ -16,9 +16,9 @@ from ....modules.auth.forms import UserForm
 @user_management_bp.before_request 
 @login_required 
 def admin_required():
-    if not current_user.is_authenticated or current_user.user_role != 'admin':
+    if not current_user.is_authenticated or current_user.user_role != User.ROLE_ADMIN:
         flash('Bạn không có quyền truy cập trang quản trị người dùng.', 'danger')
-        abort(403) 
+        abort(403)
 
 # Route để hiển thị danh sách người dùng
 @user_management_bp.route('/') # Đường dẫn gốc của Blueprint user_management

--- a/mindstack_app/modules/auth/forms.py
+++ b/mindstack_app/modules/auth/forms.py
@@ -1,11 +1,12 @@
 # File: Mindstack/web/mindstack_app/modules/auth/forms.py
-# Version: 1.4 - Đã thêm trường email vào UserForm để khắc phục lỗi NOT NULL constraint failed.
+# Version: 1.5 - Bổ sung quản lý role bằng hằng số và cập nhật form đăng ký/ quản trị người dùng.
 # Mục đích: Định nghĩa các lớp form cho Đăng nhập, Đăng ký và quản lý Người dùng.
 
 from flask_wtf import FlaskForm
 from wtforms import StringField, PasswordField, BooleanField, SubmitField, SelectField
 from wtforms.validators import DataRequired, EqualTo, ValidationError, Optional, Email
-from ...models import User 
+from flask_login import current_user
+from ...models import User
 
 class LoginForm(FlaskForm):
     """
@@ -21,9 +22,10 @@ class RegistrationForm(FlaskForm):
     Form đăng ký.
     """
     username = StringField('Tên đăng nhập', validators=[DataRequired(message="Vui lòng nhập tên đăng nhập.")])
-    password = PasswordField('Mật khẩu', validators=[DataRequired(message="Vui lòng nhập mật khẩu.")]) 
+    email = StringField('Email', validators=[DataRequired(message="Vui lòng nhập email."), Email(message="Email không hợp lệ.")])
+    password = PasswordField('Mật khẩu', validators=[DataRequired(message="Vui lòng nhập mật khẩu.")])
     password2 = PasswordField(
-        'Nhập lại mật khẩu', validators=[DataRequired(message="Vui lòng xác nhận mật khẩu."), EqualTo('password', message='Mật khẩu không khớp.')]) 
+        'Nhập lại mật khẩu', validators=[DataRequired(message="Vui lòng xác nhận mật khẩu."), EqualTo('password', message='Mật khẩu không khớp.')])
     submit = SubmitField('Đăng ký')
 
     def validate_username(self, username):
@@ -34,6 +36,14 @@ class RegistrationForm(FlaskForm):
         if user is not None:
             raise ValidationError('Tên đăng nhập này đã được sử dụng.')
 
+    def validate_email(self, email):
+        """
+        Đảm bảo địa chỉ email chưa được đăng ký.
+        """
+        user = User.query.filter_by(email=email.data).first()
+        if user is not None:
+            raise ValidationError('Email này đã được sử dụng.')
+
 class UserForm(FlaskForm):
     """
     Form để thêm hoặc sửa người dùng bởi admin.
@@ -43,10 +53,31 @@ class UserForm(FlaskForm):
     email = StringField('Email', validators=[DataRequired(message="Vui lòng nhập email."), Email(message="Email không hợp lệ.")])
     password = PasswordField('Mật khẩu', validators=[Optional()]) # Luôn Optional trong form
     password2 = PasswordField('Nhập lại mật khẩu', validators=[Optional(), EqualTo('password', message='Mật khẩu không khớp.')]) # Luôn Optional
-    user_role = SelectField('Quyền người dùng', choices=[('user', 'Người dùng'), ('admin', 'Quản trị viên')], validators=[DataRequired()])
+    user_role = SelectField('Quyền người dùng', validators=[DataRequired()])
     submit = SubmitField('Lưu')
 
     # Xóa phương thức __init__ tùy chỉnh và original_data_setter.
+
+    def __init__(self, *args, include_anonymous=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        allow_anonymous = include_anonymous
+        if allow_anonymous is None:
+            try:
+                allow_anonymous = current_user.is_authenticated and current_user.user_role == User.ROLE_ADMIN
+            except RuntimeError:
+                # Khi form được sử dụng ngoài request context (ví dụ: script CLI)
+                allow_anonymous = False
+
+        role_choices = [
+            (User.ROLE_USER, User.ROLE_LABELS[User.ROLE_USER]),
+            (User.ROLE_FREE, User.ROLE_LABELS[User.ROLE_FREE]),
+            (User.ROLE_ADMIN, User.ROLE_LABELS[User.ROLE_ADMIN]),
+        ]
+        if allow_anonymous:
+            role_choices.append((User.ROLE_ANONYMOUS, User.ROLE_LABELS[User.ROLE_ANONYMOUS]))
+        self.user_role.choices = role_choices
+        if not self.user_role.data:
+            self.user_role.data = User.ROLE_FREE
 
     def validate_username(self, username_field):
         """
@@ -61,3 +92,4 @@ class UserForm(FlaskForm):
         existing_user = User.query.filter(User.username == username_field.data).first()
         if existing_user and (existing_user.user_id != user_id_to_exclude):
             raise ValidationError('Tên đăng nhập này đã được sử dụng.')
+

--- a/mindstack_app/modules/auth/routes.py
+++ b/mindstack_app/modules/auth/routes.py
@@ -42,7 +42,11 @@ def register():
         
     form = RegistrationForm()
     if form.validate_on_submit():
-        user = User(username=form.username.data)
+        user = User(
+            username=form.username.data,
+            email=form.email.data,
+            user_role=User.ROLE_FREE,
+        )
         user.set_password(form.password.data)
         db.session.add(user)
         db.session.commit()

--- a/mindstack_app/modules/auth/templates/auth/register.html
+++ b/mindstack_app/modules/auth/templates/auth/register.html
@@ -1,0 +1,58 @@
+{% extends "base.html" %}
+
+{% block title %}Đăng ký{% endblock %}
+
+{% block content %}
+<div class="flex items-center justify-center min-h-screen -mt-24">
+    <div class="w-full md:w-1/2 lg:w-1/3">
+        <div class="bg-white shadow-lg p-8 border border-gray-200 rounded-xl">
+            <h2 class="text-2xl font-bold text-center mb-6">Đăng ký</h2>
+            <form action="{{ url_for('auth.register') }}" method="post" class="space-y-6">
+                {{ form.csrf_token }}
+                <div>
+                    {{ form.username.label(class="block text-sm font-medium text-gray-700") }}
+                    {{ form.username(class="mt-1 block w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500", placeholder="Tên đăng nhập") }}
+                    {% if form.username.errors %}
+                        <div class="text-red-500 text-xs mt-1">
+                            {% for error in form.username.errors %}<p>{{ error }}</p>{% endfor %}
+                        </div>
+                    {% endif %}
+                </div>
+                <div>
+                    {{ form.email.label(class="block text-sm font-medium text-gray-700") }}
+                    {{ form.email(class="mt-1 block w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500", placeholder="Email") }}
+                    {% if form.email.errors %}
+                        <div class="text-red-500 text-xs mt-1">
+                            {% for error in form.email.errors %}<p>{{ error }}</p>{% endfor %}
+                        </div>
+                    {% endif %}
+                </div>
+                <div>
+                    {{ form.password.label(class="block text-sm font-medium text-gray-700") }}
+                    {{ form.password(class="mt-1 block w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500", placeholder="Mật khẩu") }}
+                    {% if form.password.errors %}
+                        <div class="text-red-500 text-xs mt-1">
+                            {% for error in form.password.errors %}<p>{{ error }}</p>{% endfor %}
+                        </div>
+                    {% endif %}
+                </div>
+                <div>
+                    {{ form.password2.label(class="block text-sm font-medium text-gray-700") }}
+                    {{ form.password2(class="mt-1 block w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500", placeholder="Nhập lại mật khẩu") }}
+                    {% if form.password2.errors %}
+                        <div class="text-red-500 text-xs mt-1">
+                            {% for error in form.password2.errors %}<p>{{ error }}</p>{% endfor %}
+                        </div>
+                    {% endif %}
+                </div>
+                <div>
+                    {{ form.submit(class="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500") }}
+                </div>
+            </form>
+            <div class="text-center mt-6">
+                <small class="text-gray-600">Đã có tài khoản? <a href="{{ url_for('auth.login') }}" class="font-medium text-blue-600 hover:text-blue-500">Đăng nhập</a></small>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- define reusable role constants on the `User` model, set the default to the free tier, and reuse them when seeding the admin account
- extend authentication forms, routes, and templates so registrations capture email addresses and assign the free role by default
- update admin access guards and user-management forms to surface the new roles while letting administrators choose the anonymous role when appropriate

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d01f7626ac8326889b99ebc59c999a