### PR TITLE
Mask anonymous leaderboard entries for non-admin viewers

### DIFF
--- a/mindstack_app/modules/stats/routes.py
+++ b/mindstack_app/modules/stats/routes.py
@@ -9,9 +9,14 @@ from ...models import db, User, ScoreLog, FlashcardProgress, QuizProgress, Learn
 from sqlalchemy import func
 from datetime import datetime, timedelta, date
 
-def get_leaderboard_data_internal(sort_by, timeframe):
-    """
-    Hàm nội bộ để lấy dữ liệu bảng xếp hạng động.
+
+def get_leaderboard_data_internal(sort_by, timeframe, viewer=None):
+    """Hàm nội bộ để lấy dữ liệu bảng xếp hạng động.
+
+    Args:
+        sort_by (str): Tiêu chí sắp xếp.
+        timeframe (str): Mốc thời gian lọc dữ liệu.
+        viewer (User | None): Người đang xem bảng xếp hạng, dùng để ẩn danh nếu cần.
     """
     today = date.today()
     start_date = None
@@ -26,24 +31,53 @@ def get_leaderboard_data_internal(sort_by, timeframe):
         return []
 
     query = db.session.query(
+        User.user_id,
         User.username,
+        User.user_role,
         func.sum(ScoreLog.score_change).label('value')
     ).join(ScoreLog, User.user_id == ScoreLog.user_id)
 
     if start_date:
         query = query.filter(ScoreLog.timestamp >= start_date)
 
-    results = query.group_by(User.user_id).order_by(func.sum(ScoreLog.score_change).desc()).limit(10).all()
+    results = (
+        query
+        .group_by(User.user_id, User.username, User.user_role)
+        .order_by(func.sum(ScoreLog.score_change).desc())
+        .limit(10)
+        .all()
+    )
 
-    leaderboard_data = [{
-        'username': user.username,
-        'current_period_score': user.value or 0,
-        'total_reviews': 0, 
-        'learned_cards': 0,
-        'new_cards_today': 0,
-        'total_quiz_answers': 0,
-    } for user in results]
-    
+    placeholder_username = 'Người dùng ẩn danh'
+    viewer_role = getattr(viewer, 'user_role', None)
+    viewer_id = getattr(viewer, 'user_id', None)
+
+    leaderboard_data = []
+    for user in results:
+        is_anonymous = user.user_role == User.ROLE_ANONYMOUS
+        is_viewer = viewer_id is not None and user.user_id == viewer_id
+        can_view_real_name = (
+            viewer_role == User.ROLE_ADMIN
+            or is_viewer
+        )
+        mask_username = is_anonymous and not can_view_real_name
+        display_username = user.username if not mask_username else placeholder_username
+
+        leaderboard_data.append({
+            'user_id': user.user_id if not mask_username else None,
+            'user_role': user.user_role,
+            'username': display_username,
+            'display_username': display_username,
+            'is_anonymous': is_anonymous,
+            'is_username_masked': mask_username,
+            'is_viewer': is_viewer,
+            'current_period_score': user.value or 0,
+            'total_reviews': 0,
+            'learned_cards': 0,
+            'new_cards_today': 0,
+            'total_quiz_answers': 0,
+        })
+
     return leaderboard_data
 
 @stats_bp.route('/')
@@ -54,7 +88,7 @@ def dashboard():
     """
     initial_sort_by = request.args.get('sort_by', 'total_score')
     initial_timeframe = request.args.get('timeframe', 'all_time')
-    leaderboard_data = get_leaderboard_data_internal(initial_sort_by, initial_timeframe)
+    leaderboard_data = get_leaderboard_data_internal(initial_sort_by, initial_timeframe, viewer=current_user)
     
     # Dữ liệu cho các thẻ thống kê tổng quan
     dashboard_data = {
@@ -85,7 +119,7 @@ def get_leaderboard_data_api():
     """API endpoint để tải lại dữ liệu bảng xếp hạng một cách động."""
     sort_by = request.args.get('sort_by', 'total_score')
     timeframe = request.args.get('timeframe', 'all_time')
-    data = get_leaderboard_data_internal(sort_by, timeframe)
+    data = get_leaderboard_data_internal(sort_by, timeframe, viewer=current_user)
     return jsonify({'success': True, 'data': data})
 
 @stats_bp.route('/api/heatmap-data')

--- a/mindstack_app/modules/stats/templates/_leaderboard_list.html
+++ b/mindstack_app/modules/stats/templates/_leaderboard_list.html
@@ -9,7 +9,13 @@
                 {% elif loop.index == 3 %}<i class="fas fa-medal bronze-medal"></i>
                 {% else %}{{ loop.index }}{% endif %}
             </span>
-            <span class="username">{{ entry.username or 'N/A' }}</span>
+            <span class="username">
+                {% if entry.is_username_masked %}
+                    {{ entry.display_username or 'Người dùng ẩn danh' }}
+                {% else %}
+                    {{ entry.display_username or entry.username or 'N/A' }}
+                {% endif %}
+            </span>
             <span class="score-value">
                 {% if current_sort_by == 'total_score' %}{{ entry.current_period_score }} điểm
                 {% else %}

--- a/mindstack_app/modules/stats/templates/statistics.html
+++ b/mindstack_app/modules/stats/templates/statistics.html
@@ -238,7 +238,9 @@
                         else if (index === 2) rankSpan.innerHTML = '<i class="fas fa-medal bronze-medal"></i>';
                         else rankSpan.textContent = index + 1;
 
-                        clone.querySelector('.username').textContent = entry.username || 'N/A';
+                        const usernameText = entry.display_username || entry.username || 'N/A';
+                        const usernameElement = clone.querySelector('.username');
+                        usernameElement.textContent = usernameText;
                         clone.querySelector('.score-value').textContent = `${entry.current_period_score} điểm`;
                         
                         listContainer.appendChild(clone);


### PR DESCRIPTION
## Summary
- pass the current viewer into leaderboard data generation and mask anonymous usernames for non-admin viewers
- update the statistics dashboard and leaderboard API/template rendering to use masked display names consistently

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0216242dc8326ac07650b1a27cb96