### PR TITLE
Restrict public sharing features for free users

### DIFF
--- a/mindstack_app/modules/content_management/courses/templates/_add_edit_course_set_bare.html
+++ b/mindstack_app/modules/content_management/courses/templates/_add_edit_course_set_bare.html
@@ -60,13 +60,15 @@
                     {{ form.tags(class="mt-1 block w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500", placeholder="ví dụ: Lập trình, Marketing, Tiếng Anh") }}
                 </div>
 
+                {% if current_user.user_role != 'free' %}
                 <div>
-                    <label class="block text-sm font-medium text-gray-700">Trạng thái:</label>
+                    <label class="block text-sm font-medium text-gray-700">Trạng thái công khai:</label>
                     <div class="flex items-center mt-2">
                         {{ form.is_public(class="h-4 w-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500") }}
                         {{ form.is_public.label(class="ml-2 block text-sm text-gray-900") }}
                     </div>
                 </div>
+                {% endif %}
 
                 <div class="border-t border-gray-200 pt-6">
                     {{ form.ai_prompt.label(class="block text-sm font-medium text-gray-700") }}

--- a/mindstack_app/modules/content_management/courses/templates/_courses_list.html
+++ b/mindstack_app/modules/content_management/courses/templates/_courses_list.html
@@ -50,7 +50,7 @@
                         </button>
                         {% endif %}
                         
-                        {% if current_user.user_role == 'admin' or set.creator_user_id == current_user.user_id %}
+                        {% if current_user.user_role != 'free' and (current_user.user_role == 'admin' or set.creator_user_id == current_user.user_id) %}
                         <a href="{{ url_for('content_management.manage_contributors', container_id=set.container_id) }}" class="text-gray-500 hover:text-blue-600 transition-colors duration-200" title="Quản lý quyền">
                             <i class="fas fa-users"></i>
                         </a>

--- a/mindstack_app/modules/content_management/flashcards/templates/_add_edit_flashcard_set_bare.html
+++ b/mindstack_app/modules/content_management/flashcards/templates/_add_edit_flashcard_set_bare.html
@@ -48,13 +48,15 @@
                     {{ form.tags(class="mt-1 block w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500", placeholder="ví dụ: Kanji, N5, Tiếng Nhật") }}
                 </div>
 
+                {% if current_user.user_role != 'free' %}
                 <div>
-                    <label class="block text-sm font-medium text-gray-700">Trạng thái:</label>
+                    <label class="block text-sm font-medium text-gray-700">Trạng thái công khai:</label>
                     <div class="flex items-center mt-2">
                         {{ form.is_public(class="h-4 w-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500") }}
                         {{ form.is_public.label(class="ml-2 block text-sm text-gray-900") }}
                     </div>
                 </div>
+                {% endif %}
 
                 <div class="border-t border-gray-200 pt-6">
                     {{ form.ai_prompt.label(class="block text-sm font-medium text-gray-700") }}
@@ -116,11 +118,13 @@
                     if (data.ai_prompt) form.querySelector('[name="ai_prompt"]').value = data.ai_prompt;
                     
                     const isPublicCheckbox = form.querySelector('[name="is_public"]');
-                    if (data.is_public) {
-                        const isPublicValue = String(data.is_public).toLowerCase();
-                        isPublicCheckbox.checked = isPublicValue === 'true' || isPublicValue === '1';
-                    } else {
-                        isPublicCheckbox.checked = false;
+                    if (isPublicCheckbox) {
+                        if (data.is_public) {
+                            const isPublicValue = String(data.is_public).toLowerCase();
+                            isPublicCheckbox.checked = isPublicValue === 'true' || isPublicValue === '1';
+                        } else {
+                            isPublicCheckbox.checked = false;
+                        }
                     }
                 } else {
                     console.warn(result.message || 'Không thể đọc sheet Info từ file.');

--- a/mindstack_app/modules/content_management/flashcards/templates/_flashcard_sets_list.html
+++ b/mindstack_app/modules/content_management/flashcards/templates/_flashcard_sets_list.html
@@ -49,7 +49,7 @@
                         </button>
                         {% endif %}
                         
-                        {% if current_user.user_role == 'admin' or set.creator_user_id == current_user.user_id %}
+                        {% if current_user.user_role != 'free' and (current_user.user_role == 'admin' or set.creator_user_id == current_user.user_id) %}
                         <a href="{{ url_for('content_management.manage_contributors', container_id=set.container_id) }}" class="text-gray-500 hover:text-blue-600 transition-colors duration-200" title="Quản lý quyền">
                             <i class="fas fa-users"></i>
                         </a>

--- a/mindstack_app/modules/content_management/quizzes/routes.py
+++ b/mindstack_app/modules/content_management/quizzes/routes.py
@@ -18,6 +18,15 @@ from ....modules.shared.utils.search import apply_search_filter
 quizzes_bp = Blueprint('content_management_quizzes', __name__,
                         template_folder='templates') # Đã cập nhật đường dẫn template
 
+
+def _apply_is_public_restrictions(form):
+    """Disable public toggle for free users and ensure value stays False."""
+    if hasattr(form, 'is_public') and current_user.user_role == 'free':
+        form.is_public.data = False
+        existing_render_kw = dict(form.is_public.render_kw or {})
+        existing_render_kw['disabled'] = True
+        form.is_public.render_kw = existing_render_kw
+
 def _process_relative_url(url):
     """
     Mô tả: Tiền xử lý URL tương đối, thêm 'uploads/' nếu cần.
@@ -118,6 +127,7 @@ def add_quiz_set():
     Thêm một bộ Quiz mới.
     """
     form = QuizSetForm()
+    _apply_is_public_restrictions(form)
     if form.validate_on_submit():
         flash_message = ''
         flash_category = ''
@@ -129,7 +139,7 @@ def add_quiz_set():
                 title=form.title.data,
                 description=form.description.data,
                 tags=form.tags.data,
-                is_public=form.is_public.data,
+                is_public=False if current_user.user_role == 'free' else form.is_public.data,
                 ai_settings={'custom_prompt': form.ai_prompt.data} if form.ai_prompt.data else None
             )
             db.session.add(new_set)
@@ -270,11 +280,12 @@ def edit_quiz_set(set_id):
         abort(403)
     
     form = QuizSetForm(obj=quiz_set)
+    _apply_is_public_restrictions(form)
     if form.validate_on_submit():
         quiz_set.title = form.title.data
         quiz_set.description = form.description.data
         quiz_set.tags = form.tags.data
-        quiz_set.is_public = form.is_public.data
+        quiz_set.is_public = False if current_user.user_role == 'free' else form.is_public.data
         quiz_set.ai_settings = {'custom_prompt': form.ai_prompt.data} if form.ai_prompt.data else None
         db.session.commit()
         flash('Bộ câu hỏi đã được cập nhật!', 'success')

--- a/mindstack_app/modules/content_management/quizzes/templates/_add_edit_quiz_set_bare.html
+++ b/mindstack_app/modules/content_management/quizzes/templates/_add_edit_quiz_set_bare.html
@@ -48,13 +48,15 @@
                     {{ form.tags(class="mt-1 block w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500", placeholder="ví dụ: Toán, Lịch sử, Tiếng Anh") }}
                 </div>
 
+                {% if current_user.user_role != 'free' %}
                 <div>
-                    <label class="block text-sm font-medium text-gray-700">Trạng thái:</label>
+                    <label class="block text-sm font-medium text-gray-700">Trạng thái công khai:</label>
                     <div class="flex items-center mt-2">
                         {{ form.is_public(class="h-4 w-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500") }}
                         {{ form.is_public.label(class="ml-2 block text-sm text-gray-900") }}
                     </div>
                 </div>
+                {% endif %}
 
                 <div class="border-t border-gray-200 pt-6">
                     {{ form.ai_prompt.label(class="block text-sm font-medium text-gray-700") }}
@@ -118,11 +120,13 @@
                     if (data.ai_prompt) form.querySelector('[name="ai_prompt"]').value = data.ai_prompt;
                     
                     const isPublicCheckbox = form.querySelector('[name="is_public"]');
-                    if (data.is_public) {
-                        const isPublicValue = String(data.is_public).toLowerCase();
-                        isPublicCheckbox.checked = isPublicValue === 'true' || isPublicValue === '1';
-                    } else {
-                        isPublicCheckbox.checked = false;
+                    if (isPublicCheckbox) {
+                        if (data.is_public) {
+                            const isPublicValue = String(data.is_public).toLowerCase();
+                            isPublicCheckbox.checked = isPublicValue === 'true' || isPublicValue === '1';
+                        } else {
+                            isPublicCheckbox.checked = false;
+                        }
                     }
                 } else {
                     console.warn(result.message || 'Không thể đọc sheet Info từ file.');

--- a/mindstack_app/modules/content_management/quizzes/templates/_quiz_sets_list.html
+++ b/mindstack_app/modules/content_management/quizzes/templates/_quiz_sets_list.html
@@ -49,7 +49,7 @@
                         </button>
                         {% endif %}
                         
-                        {% if current_user.user_role == 'admin' or set.creator_user_id == current_user.user_id %}
+                        {% if current_user.user_role != 'free' and (current_user.user_role == 'admin' or set.creator_user_id == current_user.user_id) %}
                         <a href="{{ url_for('content_management.manage_contributors', container_id=set.container_id) }}" class="text-gray-500 hover:text-blue-600 transition-colors duration-200" title="Quản lý quyền">
                             <i class="fas fa-users"></i>
                         </a>

--- a/mindstack_app/modules/content_management/routes.py
+++ b/mindstack_app/modules/content_management/routes.py
@@ -38,6 +38,9 @@ def manage_contributors(container_id):
     Quản lý người đóng góp cho một LearningContainer cụ thể.
     """
     container = LearningContainer.query.get_or_404(container_id)
+    creator = container.creator
+    if creator and creator.user_role == User.ROLE_FREE:
+        abort(403)
 
     if current_user.user_role != 'admin' and container.creator_user_id != current_user.user_id:
         abort(403)
@@ -54,6 +57,8 @@ def manage_contributors(container_id):
             flash(f'Không tìm thấy người dùng với email: {email_to_add}.', 'danger')
         elif user_to_add.user_id == container.creator_user_id:
             flash('Không thể thêm chính người tạo làm người đóng góp.', 'warning')
+        elif user_to_add.user_role in {User.ROLE_FREE, User.ROLE_ANONYMOUS}:
+            flash('Không thể thêm tài khoản miễn phí hoặc ẩn danh làm người đóng góp.', 'danger')
         else:
             existing_contributor = ContainerContributor.query.filter_by(
                 container_id=container_id,


### PR DESCRIPTION
## Summary
- force new and edited flashcard, quiz, and course sets to remain private for free accounts while disabling the visibility toggle in forms
- hide contributor management controls for free viewers and guard contributor management routes against free creators and invitees
- update modal templates to omit the public status section for free users and harden related JavaScript when the checkbox is absent

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0215e40b88326bfbb3aeb6b7141ec