### PR TITLE
Adjust course session layout for mobile

### DIFF
--- a/mindstack_app/modules/learning/course_learning/templates/course_session.html
+++ b/mindstack_app/modules/learning/course_learning/templates/course_session.html
@@ -74,11 +74,24 @@
             word-wrap: break-word;  /* THÊM MỚI: Tự động ngắt dòng dài */
             color: #374151;
         }
+
+        @media (max-width: 640px) {
+            .course-session-container {
+                padding-left: 0;
+                padding-right: 0;
+            }
+
+            .course-session-container .lesson-content-wrapper {
+                padding: 0.75rem;
+                border-radius: 0;
+                box-shadow: none;
+            }
+        }
     </style>
 {% endblock %}
 
 {% block content %}
-<div class="container mx-auto px-4 py-8">
+<div class="container course-session-container mx-auto px-4 py-8">
     <div class="max-w-4xl mx-auto">
         <a href="{{ url_for('learning.course_learning.course_learning_dashboard') }}" class="text-blue-600 hover:text-blue-800 mb-6 inline-block">
             <i class="fas fa-arrow-left mr-2"></i>Quay lại danh sách khóa học


### PR DESCRIPTION
## Summary
- add a dedicated `course-session-container` class to the course session layout wrapper
- introduce a mobile media query to collapse container padding and tighten the lesson content wrapper for small screens

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d166f8cb648326bca6d0f8ba3ecc95