### PR TITLE
Fix note placeholder whitespace trimming

### DIFF
--- a/mindstack_app/modules/learning/course_learning/templates/course_session.html
+++ b/mindstack_app/modules/learning/course_learning/templates/course_session.html
@@ -120,7 +120,7 @@
 
                 <div id="note-display-view">
                     <div id="note-content-display" class="note-content-display">
-                        {% if note and note.content %}{{ note.content }}{% else %}<span class="text-gray-500 italic">Bạn chưa có ghi chú nào cho bài học này.</span>{% endif %}
+                        {% if note and note.content -%}{{ note.content }}{%- else -%}<span class="text-gray-500 italic">Bạn chưa có ghi chú nào cho bài học này.</span>{%- endif %}
                     </div>
                 </div>
 


### PR DESCRIPTION
## Summary
- trim whitespace in the note placeholder block so the fallback span is rendered without leading indentation
- keep real note content rendering unchanged by preserving the existing white-space handling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d166f8d76883269c876ec0b8961199