### PR TITLE
Fix note content whitespace rendering

### DIFF
--- a/mindstack_app/modules/learning/course_learning/templates/course_session.html
+++ b/mindstack_app/modules/learning/course_learning/templates/course_session.html
@@ -132,9 +132,7 @@
                 </div>
 
                 <div id="note-display-view">
-                    <div id="note-content-display" class="note-content-display">
-                        {% if note and note.content -%}{{ note.content }}{%- else -%}<span class="text-gray-500 italic">Bạn chưa có ghi chú nào cho bài học này.</span>{%- endif %}
-                    </div>
+                    <div id="note-content-display" class="note-content-display">{% if note and note.content -%}{{ note.content }}{%- else -%}<span class="text-gray-500 italic">Bạn chưa có ghi chú nào cho bài học này.</span>{%- endif %}</div>
                 </div>
 
                 <div id="note-edit-view" style="display: none;">


### PR DESCRIPTION
## Summary
- move the note content conditional inline with the note container div to avoid rendering leading whitespace

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d16deb6f888326aab17802f13c396b