### PR TITLE
Align course session spacing with shared layout

### DIFF
--- a/mindstack_app/modules/learning/course_learning/templates/course_session.html
+++ b/mindstack_app/modules/learning/course_learning/templates/course_session.html
@@ -91,7 +91,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="container course-session-container mx-auto px-4 py-8">
+<div class="container course-session-container mx-auto px-1 py-4 sm:px-6 sm:py-6 lg:px-8 lg:py-8">
     <div class="max-w-4xl mx-auto">
         <a href="{{ url_for('learning.course_learning.course_learning_dashboard') }}" class="text-blue-600 hover:text-blue-800 mb-6 inline-block">
             <i class="fas fa-arrow-left mr-2"></i>Quay lại danh sách khóa học


### PR DESCRIPTION
## Summary
- update the course session container padding to use the shared responsive spacing utilities
- confirm other learning templates already use the shared spacing without modifying the bespoke flashcard layout

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d16dec16648326a9b3c14de1d9497d