### PR TITLE
Adjust flashcard sessions for new and review modes

### DIFF
--- a/mindstack_app/modules/learning/flashcard_learning/config.py
+++ b/mindstack_app/modules/learning/flashcard_learning/config.py
@@ -15,5 +15,6 @@ class FlashcardLearningConfig:
         {'id': 'mixed_srs', 'name': 'Học tập tuần tự', 'algorithm_func_name': 'get_mixed_items'},
         {'id': 'new_only', 'name': 'Chỉ học thẻ mới', 'algorithm_func_name': 'get_new_only_items'},
         {'id': 'due_only', 'name': 'Ôn tập thẻ đến hạn', 'algorithm_func_name': 'get_due_items'},
+        {'id': 'all_review', 'name': 'Ôn tập toàn bộ thẻ đã học', 'algorithm_func_name': 'get_all_review_items'},
         {'id': 'hard_only', 'name': 'Ôn tập thẻ khó', 'algorithm_func_name': 'get_hard_items'},
     ]


### PR DESCRIPTION
## Summary
- ensure new flashcards record first seen timestamps, schedule an initial due time when continuing, and skip SRS adjustments for the full review mode
- add a query for reviewing every learned flashcard and wire it into the session manager so each mode serves the correct card set
- surface the new "Ôn tập toàn bộ thẻ đã học" mode in the configuration list

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3eb16e0b483268e3064328ea59d6f