### PR TITLE
Add autoplay for flashcard back side on flip

### DIFF
--- a/mindstack_app/modules/learning/flashcard_learning/templates/flashcard_session.html
+++ b/mindstack_app/modules/learning/flashcard_learning/templates/flashcard_session.html
@@ -927,10 +927,18 @@
       return generateAndPlayAudio(button, audioPlayer, { awaitCompletion, suppressLoadingUi, restart });
     }
 
+    function autoPlaySide(side) {
+      const button = document.querySelector(`.play-audio-btn[data-side="${side}"]`);
+      if (!button) return;
+      playAudioForButton(button, { suppressLoadingUi: true }).catch(() => {});
+    }
+
     function autoPlayFrontSide() {
-      const frontButton = document.querySelector('.play-audio-btn[data-side="front"]');
-      if (!frontButton) return;
-      playAudioForButton(frontButton, { suppressLoadingUi: true }).catch(() => {});
+      autoPlaySide('front');
+    }
+
+    function autoPlayBackSide() {
+      autoPlaySide('back');
     }
 
     function cancelAutoplaySequence() {
@@ -1215,6 +1223,9 @@
             actions?.classList.add('visible');
             flipBtn.style.display = 'none';
             setTimeout(adjustCardLayout, 0);
+            if (!isAutoplaySession) {
+                autoPlayBackSide();
+            }
         });
       }
       


### PR DESCRIPTION
## Summary
- refactor flashcard autoplay helper to support both front and back sides
- automatically play the back-side audio when a user flips the card in manual sessions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d425427c00832697c74777611b9c61