### PR TITLE
Fix flashcard card face visibility and audio overlap

### DIFF
--- a/mindstack_app/modules/learning/flashcard_learning/templates/flashcard_session.html
+++ b/mindstack_app/modules/learning/flashcard_learning/templates/flashcard_session.html
@@ -166,7 +166,7 @@
         width: 100%;
         height: 100%;
         position: relative;
-        background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
+        background-color: #ffffff;
         border: 1px solid rgba(148, 163, 184, 0.25);
         border-radius: 18px;
         box-shadow: 0 24px 48px rgba(15, 23, 42, 0.08);
@@ -186,8 +186,8 @@
         position: absolute;
         inset: -1px;
         border-radius: inherit;
-        background: radial-gradient(120% 120% at 90% 10%, rgba(var(--card-accent-rgb), 0.18), transparent 60%);
-        opacity: 0.85;
+        background: transparent;
+        opacity: 0;
         pointer-events: none;
         z-index: 0;
     }
@@ -233,8 +233,10 @@
         min-height: 0;
         backface-visibility: hidden;
         -webkit-backface-visibility: hidden;
-        transition: transform .6s ease-in-out;
+        transition: transform .6s ease-in-out, opacity .3s ease-in-out;
         z-index: 1;
+        opacity: 0;
+        pointer-events: none;
     }
 
     .front {
@@ -245,12 +247,26 @@
         transform: rotateY(180deg);
     }
 
+    .flashcard-card:not(.flipped) .front {
+        opacity: 1;
+        pointer-events: auto;
+    }
+
+    .flashcard-card:not(.flipped) .back {
+        opacity: 0;
+        pointer-events: none;
+    }
+
     .flashcard-card.flipped .front {
         transform: rotateY(180deg);
+        opacity: 0;
+        pointer-events: none;
     }
 
     .flashcard-card.flipped .back {
         transform: rotateY(360deg);
+        opacity: 1;
+        pointer-events: auto;
     }
 
     .card-toolbar {
@@ -263,7 +279,7 @@
         top: 0;
         left: 0;
         z-index: 10;
-        background: linear-gradient(135deg, rgba(var(--card-accent-rgb), 0.12), rgba(255, 255, 255, 0.9));
+        background: rgba(255, 255, 255, 0.92);
         border-bottom: 1px solid rgba(148, 163, 184, 0.18);
         backdrop-filter: blur(8px);
     }
@@ -860,6 +876,23 @@
       });
     }
 
+    function stopAllFlashcardAudio(exceptAudio = null) {
+      const audioElements = document.querySelectorAll('#flashcard-content audio');
+      audioElements.forEach(audioEl => {
+        if (exceptAudio && audioEl === exceptAudio) {
+          return;
+        }
+        try {
+          if (!audioEl.paused) {
+            audioEl.pause();
+          }
+          audioEl.currentTime = 0;
+        } catch (err) {
+          console.warn('Không thể dừng audio:', err);
+        }
+      });
+    }
+
     function playAudioForButton(button, options = {}) {
       if (!button) return Promise.resolve();
       const audioPlayer = document.querySelector(button.dataset.audioTarget);
@@ -873,9 +906,11 @@
       const hasAudioSource = audioPlayer.src && audioPlayer.src !== window.location.href;
 
       if (hasAudioSource) {
+        stopAllFlashcardAudio(audioPlayer);
         return playAudioAfterLoad(audioPlayer, { restart, awaitCompletion });
       }
 
+      stopAllFlashcardAudio(audioPlayer);
       return generateAndPlayAudio(button, audioPlayer, { awaitCompletion, suppressLoadingUi, restart });
     }
 
@@ -897,6 +932,7 @@
       currentAutoplayToken += 1;
       currentAutoplayTimeouts.forEach(timeoutId => clearTimeout(timeoutId));
       currentAutoplayTimeouts = [];
+      stopAllFlashcardAudio();
     }
 
     function waitForAutoplayDelay(token) {
@@ -1129,6 +1165,8 @@
       if (cardCategory) {
         cardClassNames.push(`flashcard-card--${cardCategory}`);
       }
+
+      stopAllFlashcardAudio();
 
       const html = `
       <div class="flashcard-card-container">
@@ -1565,6 +1603,7 @@
     }
 
     async function getNextFlashcardBatch(){
+      stopAllFlashcardAudio();
       flashcardContentDiv.innerHTML = `<div class="flex flex-col items-center justify-center h-full text-blue-500 min-h-[300px]"><i class="fas fa-spinner fa-spin text-4xl mb-3"></i><p>Đang tải thẻ...</p></div>`;
       try {
         const res = await fetch(getFlashcardBatchUrl, {headers: {'X-Requested-With': 'XMLHttpRequest'}});
@@ -1598,6 +1637,7 @@
     }
 
     async function submitFlashcardAnswer(itemId, answer){
+      stopAllFlashcardAudio();
       try {
         const res = await fetch(submitAnswerUrl, {
           method: 'POST',


### PR DESCRIPTION
## Summary
- remove unintended gradients from the flashcard card and ensure only the buttons carry accent styling
- keep the front toolbar visible by default and hide the reverse toolbar until the card is flipped
- stop any playing flashcard audio whenever cards change, autoplay is cancelled, or a new recording starts

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4b12c7f088326bb14cab6b9d8fd16