### PR TITLE
Adjust flashcard rating buttons to compact grid layout

### DIFF
--- a/mindstack_app/modules/learning/flashcard_learning/templates/flashcard_session.html
+++ b/mindstack_app/modules/learning/flashcard_learning/templates/flashcard_session.html
@@ -456,7 +456,6 @@
     /* Nút đánh giá trong thẻ */
     .actions {
         display: none;
-        flex-wrap: wrap;
         gap: 1rem;
         justify-content: center;
         padding: 1.25rem 1.5rem;
@@ -472,7 +471,9 @@
     }
 
     .actions.visible {
-        display: flex;
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        align-items: stretch;
     }
 
     .btn {
@@ -494,7 +495,7 @@
     }
 
     .actions .btn {
-        flex: 1 1 180px;
+        width: 100%;
         min-width: 0;
         max-width: 100%;
         white-space: normal;
@@ -519,43 +520,31 @@
     .rating-btn {
         color: #fff;
         border-radius: 1rem;
-        padding: 1rem 1.3rem;
-        justify-content: flex-start;
+        padding: 1.1rem 1.25rem;
+        justify-content: center;
         position: relative;
         overflow: hidden;
-        gap: 0.9rem;
+        gap: 0.75rem;
         box-shadow: 0 18px 34px rgba(15, 23, 42, 0.12);
+        flex-direction: column;
+        text-align: center;
     }
 
     .rating-btn .rating-btn__icon {
         display: inline-flex;
         align-items: center;
         justify-content: center;
-        width: 2.25rem;
-        height: 2.25rem;
+        width: 2.75rem;
+        height: 2.75rem;
         border-radius: 999px;
         background: rgba(255, 255, 255, 0.18);
-        font-size: 1.15rem;
-    }
-
-    .rating-btn .rating-btn__text {
-        display: flex;
-        flex-direction: column;
-        gap: 0.25rem;
-        line-height: 1.2;
+        font-size: 1.35rem;
     }
 
     .rating-btn .rating-btn__title {
         font-size: 1rem;
         font-weight: 700;
         letter-spacing: 0.01em;
-    }
-
-    .rating-btn .rating-btn__caption {
-        font-size: 0.75rem;
-        font-weight: 500;
-        letter-spacing: 0.01em;
-        color: rgba(255, 255, 255, 0.82);
     }
 
     .rating-btn--again,
@@ -577,10 +566,6 @@
     .rating-btn--hard .rating-btn__icon {
         background: rgba(15, 23, 42, 0.12);
         color: #1f2937;
-    }
-
-    .rating-btn--hard .rating-btn__caption {
-        color: rgba(30, 41, 59, 0.75);
     }
 
     .rating-btn--medium {
@@ -609,10 +594,13 @@
     }
 
     .actions[data-button-count="1"] .btn {
-        flex: 0 0 auto;
         min-width: 200px;
         justify-content: center;
         text-align: center;
+    }
+
+    .actions[data-button-count="4"] .rating-btn:nth-child(4) {
+        grid-column: 2 / span 1;
     }
 
     @media (max-width: 1024px) {
@@ -620,19 +608,23 @@
             padding: 1rem 1.25rem;
             gap: 0.75rem;
         }
-
-        .actions .btn {
-            flex: 1 1 calc(50% - 0.75rem);
-        }
     }
 
     @media (max-width: 640px) {
-        .actions .btn {
-            flex: 1 1 100%;
+        .actions {
+            padding: 0.85rem 1rem;
+            gap: 0.65rem;
         }
 
         .rating-btn {
-            align-items: flex-start;
+            padding: 0.9rem 1rem;
+            gap: 0.6rem;
+        }
+
+        .rating-btn .rating-btn__icon {
+            width: 2.4rem;
+            height: 2.4rem;
+            font-size: 1.15rem;
         }
     }
 
@@ -1196,30 +1188,29 @@
     function generateDynamicButtons(buttonCount) {
         const buttonSets = {
             3: [
-                { variant: 'again', value: 'quên', title: 'Quên', caption: 'Ôn lại ngay', icon: 'fas fa-redo-alt' },
-                { variant: 'hard', value: 'mơ_hồ', title: 'Mơ hồ', caption: 'Cần xem lại sớm', icon: 'fas fa-question-circle' },
-                { variant: 'easy', value: 'nhớ', title: 'Nhớ', caption: 'Đã nắm chắc', icon: 'fas fa-check-circle' }
+                { variant: 'again', value: 'quên', title: 'Quên', icon: 'fas fa-redo-alt' },
+                { variant: 'hard', value: 'mơ_hồ', title: 'Mơ hồ', icon: 'fas fa-question-circle' },
+                { variant: 'easy', value: 'nhớ', title: 'Nhớ', icon: 'fas fa-check-circle' }
             ],
             4: [
-                { variant: 'again', value: 'again', title: 'Học lại', caption: 'Đặt lịch ôn ngay', icon: 'fas fa-undo' },
-                { variant: 'very-hard', value: 'hard', title: 'Khó', caption: 'Cần luyện thêm', icon: 'fas fa-fire' },
-                { variant: 'good', value: 'good', title: 'Bình thường', caption: 'Nhớ được kha khá', icon: 'fas fa-thumbs-up' },
-                { variant: 'easy', value: 'easy', title: 'Dễ', caption: 'Rất tự tin', icon: 'fas fa-smile' }
+                { variant: 'again', value: 'again', title: 'Học lại', icon: 'fas fa-undo' },
+                { variant: 'very-hard', value: 'hard', title: 'Khó', icon: 'fas fa-fire' },
+                { variant: 'good', value: 'good', title: 'Bình thường', icon: 'fas fa-thumbs-up' },
+                { variant: 'easy', value: 'easy', title: 'Dễ', icon: 'fas fa-smile' }
             ],
             6: [
-                { variant: 'fail', value: 'fail', title: 'Rất khó', caption: 'Ôn lại ngay', icon: 'fas fa-exclamation-circle' },
-                { variant: 'very-hard', value: 'very_hard', title: 'Khó', caption: 'Chưa ổn định', icon: 'fas fa-fire' },
-                { variant: 'hard', value: 'hard', title: 'Trung bình', caption: 'Cần luyện thêm', icon: 'fas fa-adjust' },
-                { variant: 'medium', value: 'medium', title: 'Dễ', caption: 'Nhớ tương đối tốt', icon: 'fas fa-leaf' },
-                { variant: 'good', value: 'good', title: 'Rất dễ', caption: 'Tự tin trả lời', icon: 'fas fa-thumbs-up' },
-                { variant: 'very-easy', value: 'very_easy', title: 'Dễ dàng', caption: 'Thuộc lòng', icon: 'fas fa-star' }
+                { variant: 'fail', value: 'fail', title: 'Rất khó', icon: 'fas fa-exclamation-circle' },
+                { variant: 'very-hard', value: 'very_hard', title: 'Khó', icon: 'fas fa-fire' },
+                { variant: 'hard', value: 'hard', title: 'Trung bình', icon: 'fas fa-adjust' },
+                { variant: 'medium', value: 'medium', title: 'Dễ', icon: 'fas fa-leaf' },
+                { variant: 'good', value: 'good', title: 'Rất dễ', icon: 'fas fa-thumbs-up' },
+                { variant: 'very-easy', value: 'very_easy', title: 'Dễ dàng', icon: 'fas fa-star' }
             ]
         };
         const buttons = buttonSets[buttonCount] || buttonSets[3];
         return buttons.map(btn => {
             const iconHtml = btn.icon ? `<span class="rating-btn__icon"><i class="${btn.icon}"></i></span>` : '';
-            const captionHtml = btn.caption ? `<span class="rating-btn__caption">${btn.caption}</span>` : '';
-            return `<button class="btn rating-btn rating-btn--${btn.variant}" data-answer="${btn.value}">${iconHtml}<span class="rating-btn__text"><span class="rating-btn__title">${btn.title}</span>${captionHtml}</span></button>`;
+            return `<button class="btn rating-btn rating-btn--${btn.variant}" data-answer="${btn.value}">${iconHtml}<span class="rating-btn__title">${btn.title}</span></button>`;
         }).join('');
     }
     


### PR DESCRIPTION
## Summary
- simplify flashcard rating buttons to show only the icon and title labels
- arrange the answer buttons in a consistent three-column grid layout with centered placement for the fourth option
- refine button spacing for smaller screens so the compact layout remains legible

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68d4c16bdb608326ae8253a2e262757a