### PR TITLE
Refine flashcard session statistics layout

### DIFF
--- a/mindstack_app/modules/learning/flashcard_learning/templates/_flashcard_session_stats.html
+++ b/mindstack_app/modules/learning/flashcard_learning/templates/_flashcard_session_stats.html
@@ -10,12 +10,12 @@
         border: 1px solid #e2e8f0;
         border-radius: 20px;
         box-shadow: 0 24px 48px rgba(15, 23, 42, 0.08);
-        padding: 1.5rem;
+        padding: 1.25rem;
         display: flex;
         flex-direction: column;
-        gap: 1.5rem;
+        gap: 1.25rem;
         color: #0f172a;
-        max-width: 540px;
+        max-width: 520px;
         width: 100%;
         overflow-y: auto;
         max-height: 100%;
@@ -39,12 +39,12 @@
     .statistics-card__header {
         display: flex;
         justify-content: space-between;
-        align-items: flex-start;
-        gap: 1rem;
+        align-items: center;
+        gap: 0.75rem;
     }
 
     .statistics-card__subtitle {
-        font-size: 0.75rem;
+        font-size: 0.72rem;
         text-transform: uppercase;
         letter-spacing: 0.08em;
         font-weight: 600;
@@ -52,8 +52,8 @@
     }
 
     .statistics-card__title {
-        margin: 0.35rem 0 0;
-        font-size: 1.35rem;
+        margin: 0.2rem 0 0;
+        font-size: 1.15rem;
         font-weight: 700;
         color: #0f172a;
     }
@@ -62,11 +62,11 @@
         display: inline-flex;
         align-items: center;
         gap: 0.4rem;
-        padding: 0.35rem 0.75rem;
+        padding: 0.3rem 0.65rem;
         border-radius: 999px;
         background: rgba(59, 130, 246, 0.15);
         color: #1d4ed8;
-        font-size: 0.75rem;
+        font-size: 0.72rem;
         font-weight: 600;
         white-space: nowrap;
     }
@@ -77,8 +77,9 @@
 
     .session-overview {
         display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-        gap: 1rem;
+        grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+        gap: 0.75rem;
+        align-items: stretch;
     }
 
     .summary-card {
@@ -86,12 +87,12 @@
         background: #ffffff;
         border: 1px solid #e2e8f0;
         border-radius: 16px;
-        padding: 1rem 1.25rem;
+        padding: 0.9rem 1.1rem;
         overflow: hidden;
         box-shadow: 0 16px 32px rgba(15, 23, 42, 0.07);
         display: flex;
         flex-direction: column;
-        gap: 0.6rem;
+        gap: 0.5rem;
     }
 
     .summary-card::after {
@@ -116,13 +117,15 @@
     }
 
     .summary-card__value {
-        font-size: 1.85rem;
+        font-size: 1.55rem;
         font-weight: 700;
         display: flex;
         align-items: center;
-        gap: 0.5rem;
+        gap: 0.4rem;
         color: #0f172a;
         font-feature-settings: "tnum";
+        white-space: nowrap;
+        line-height: 1.1;
     }
 
     .summary-card__value i {
@@ -142,19 +145,26 @@
 
     .stats-tab-nav {
         display: flex;
-        gap: 0.4rem;
+        gap: 0.35rem;
         background: #eef2ff;
-        border-radius: 999px;
-        padding: 0.4rem;
+        border-radius: 14px;
+        padding: 0.35rem;
+        flex-wrap: nowrap;
+        overflow-x: auto;
+        scrollbar-width: none;
+    }
+
+    .stats-tab-nav::-webkit-scrollbar {
+        display: none;
     }
 
     .stats-tab-button {
-        flex: 1;
+        flex: 1 1 auto;
         border: none;
         background: transparent;
         border-radius: 999px;
-        padding: 0.55rem 0.75rem;
-        font-size: 0.85rem;
+        padding: 0.5rem 0.75rem;
+        font-size: 0.82rem;
         font-weight: 600;
         color: #64748b;
         cursor: pointer;
@@ -163,6 +173,8 @@
         align-items: center;
         justify-content: center;
         gap: 0.35rem;
+        white-space: nowrap;
+        min-width: 0;
     }
 
     .stats-tab-button i {
@@ -199,18 +211,18 @@
     .stats-section {
         display: flex;
         flex-direction: column;
-        gap: 0.9rem;
+        gap: 0.75rem;
     }
 
     .stats-section__header {
         display: flex;
         align-items: flex-start;
-        gap: 0.75rem;
+        gap: 0.6rem;
     }
 
     .stats-section__header h4 {
         margin: 0;
-        font-size: 1rem;
+        font-size: 0.98rem;
         font-weight: 700;
         color: #1f2937;
     }
@@ -343,15 +355,15 @@
 
     .insight-grid {
         display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-        gap: 0.9rem;
+        grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+        gap: 0.75rem;
     }
 
     .insight-card {
         background: #f8fafc;
         border: 1px solid #e2e8f0;
         border-radius: 14px;
-        padding: 0.85rem 1rem;
+        padding: 0.75rem 0.9rem;
         display: flex;
         flex-direction: column;
         gap: 0.35rem;
@@ -372,7 +384,7 @@
     }
 
     .insight-card__value {
-        font-size: 1.2rem;
+        font-size: 1.1rem;
         font-weight: 700;
         color: #0f172a;
     }
@@ -440,25 +452,101 @@
         color: #1e293b;
     }
 
+    .stats-section--recent .icon-bubble {
+        background: #fef3c7;
+        color: #b45309;
+        box-shadow: 0 12px 22px rgba(244, 158, 11, 0.18);
+    }
+
+    .recent-answers-track {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+        gap: 0.5rem;
+    }
+
+    .recent-answer-pill {
+        border-radius: 12px;
+        border: 1px solid #e2e8f0;
+        background: #f8fafc;
+        padding: 0.55rem 0.75rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+        min-width: 0;
+    }
+
+    .recent-answer-pill__status {
+        font-size: 0.8rem;
+        font-weight: 600;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+    }
+
+    .recent-answer-pill__status i {
+        font-size: 0.8rem;
+    }
+
+    .recent-answer-pill__time {
+        font-size: 0.75rem;
+        color: #94a3b8;
+    }
+
+    .recent-answer-pill--correct {
+        background: rgba(34, 197, 94, 0.1);
+        border-color: rgba(34, 197, 94, 0.35);
+    }
+
+    .recent-answer-pill--correct .recent-answer-pill__status {
+        color: #166534;
+    }
+
+    .recent-answer-pill--vague {
+        background: rgba(245, 158, 11, 0.12);
+        border-color: rgba(245, 158, 11, 0.35);
+    }
+
+    .recent-answer-pill--vague .recent-answer-pill__status {
+        color: #b45309;
+    }
+
+    .recent-answer-pill--incorrect {
+        background: rgba(239, 68, 68, 0.12);
+        border-color: rgba(239, 68, 68, 0.35);
+    }
+
+    .recent-answer-pill--incorrect .recent-answer-pill__status {
+        color: #b91c1c;
+    }
+
+    .recent-answer-pill--preview {
+        background: rgba(59, 130, 246, 0.12);
+        border-color: rgba(59, 130, 246, 0.35);
+    }
+
+    .recent-answer-pill--preview .recent-answer-pill__status {
+        color: #1d4ed8;
+    }
+
     .timeline-card {
         background: #ffffff;
         border: 1px dashed #cbd5f5;
         border-radius: 16px;
-        padding: 1rem 1.2rem;
+        padding: 0.9rem 1rem;
         display: flex;
         flex-direction: column;
-        gap: 0.8rem;
+        gap: 0.7rem;
     }
 
     .timeline-item {
         display: flex;
-        gap: 0.75rem;
+        gap: 0.65rem;
         align-items: flex-start;
     }
 
     .timeline-icon {
-        width: 38px;
-        height: 38px;
+        width: 34px;
+        height: 34px;
         border-radius: 12px;
         background: #eff6ff;
         color: #2563eb;
@@ -478,7 +566,7 @@
     }
 
     .timeline-value {
-        font-size: 0.95rem;
+        font-size: 0.9rem;
         font-weight: 600;
         color: #0f172a;
     }
@@ -610,13 +698,22 @@
             grid-template-columns: 1fr;
         }
         .stats-tab-nav {
-            flex-direction: column;
+            padding: 0.3rem;
+            justify-content: space-between;
         }
         .stats-tab-button {
-            width: 100%;
+            flex: 0 0 auto;
+            font-size: 0.8rem;
+            padding: 0.45rem 0.65rem;
         }
         .insight-grid {
             grid-template-columns: 1fr 1fr;
+        }
+    }
+
+    @media (max-width: 520px) {
+        .recent-answers-track {
+            grid-template-columns: 1fr;
         }
     }
 

--- a/mindstack_app/modules/learning/flashcard_learning/templates/flashcard_session.html
+++ b/mindstack_app/modules/learning/flashcard_learning/templates/flashcard_session.html
@@ -1507,6 +1507,25 @@
         const easinessFactor = typeof stats.easiness_factor === 'number' ? Number(stats.easiness_factor).toFixed(2) : '—';
         const currentStreak = Number(stats.current_streak) || 0;
         const longestStreak = Number(stats.longest_streak) || 0;
+        const formatRecentTimestamp = (value) => {
+            if (!value) return 'Không rõ';
+            const date = new Date(value);
+            if (Number.isNaN(date.getTime())) return 'Không rõ';
+            try {
+                const timePart = date.toLocaleTimeString('vi-VN', { hour: '2-digit', minute: '2-digit' });
+                const datePart = date.toLocaleDateString('vi-VN', { day: '2-digit', month: '2-digit' });
+                return `${timePart} · ${datePart}`;
+            } catch (err) {
+                return 'Không rõ';
+            }
+        };
+        const recentReviews = Array.isArray(stats.recent_reviews) ? [...stats.recent_reviews].slice(-10).reverse() : [];
+        const recentReviewConfig = {
+            'correct': { label: 'Nhớ', icon: 'fas fa-check-circle' },
+            'vague': { label: 'Mơ hồ', icon: 'fas fa-adjust' },
+            'incorrect': { label: 'Quên', icon: 'fas fa-times-circle' },
+            'preview': { label: 'Xem trước', icon: 'fas fa-eye' }
+        };
         const introNotice = isBrandNew
             ? `<div class="insight-banner"><i class="fas fa-seedling"></i><span>Thẻ mới - khám phá nội dung trước khi chấm điểm.</span></div>`
             : (isPreviewStage
@@ -1617,6 +1636,34 @@
             </div>
         `;
 
+        const recentSection = recentReviews.length
+            ? `
+                <div class="stats-section stats-section--recent">
+                    <div class="stats-section__header">
+                        <div class="icon-bubble"><i class="fas fa-history"></i></div>
+                        <div>
+                            <h4>Lượt trả lời gần đây</h4>
+                            <p>Theo dõi tối đa 10 lượt mới nhất và trạng thái ghi nhớ.</p>
+                        </div>
+                    </div>
+                    <div class="recent-answers-track">
+                        ${recentReviews.map(entry => {
+                            const resultKey = (entry.result || '').toLowerCase();
+                            const config = recentReviewConfig[resultKey] || recentReviewConfig.preview;
+                            const timestampDisplay = formatRecentTimestamp(entry.timestamp);
+                            const qualityScore = typeof entry.user_answer_quality === 'number' ? entry.user_answer_quality : '—';
+                            return `
+                                <div class="recent-answer-pill recent-answer-pill--${resultKey || 'preview'}" title="Điểm chất lượng: ${qualityScore}">
+                                    <span class="recent-answer-pill__status"><i class="${config.icon}"></i> ${config.label}</span>
+                                    <span class="recent-answer-pill__time">${timestampDisplay}</span>
+                                </div>
+                            `;
+                        }).join('')}
+                    </div>
+                </div>
+            `
+            : '';
+
         const timelineSection = `
             <div class="stats-section stats-section--timeline">
                 <div class="stats-section__header">
@@ -1671,6 +1718,7 @@
             ${introNotice}
             ${progressSection}
             ${insightSection}
+            ${recentSection}
             ${timelineSection}
             ${cardDetails}
         `;


### PR DESCRIPTION
## Summary
- tighten spacing in the flashcard statistics card so key widgets stay above the fold across screen sizes
- expose recent review attempts from flashcard stats logic and render a colour coded history block in the session view

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5097da9f08326937830e4d8eb6716