### PR TITLE
Adjust flashcard stats layout and card details placement

### DIFF
--- a/mindstack_app/modules/learning/flashcard_learning/templates/_flashcard_session_stats.html
+++ b/mindstack_app/modules/learning/flashcard_learning/templates/_flashcard_session_stats.html
@@ -76,10 +76,22 @@
     }
 
     .session-overview {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+        display: flex;
         gap: 0.75rem;
         align-items: stretch;
+        width: 100%;
+        flex-wrap: nowrap;
+        overflow-x: auto;
+        scrollbar-width: none;
+    }
+
+    .session-overview > * {
+        flex: 1 1 0;
+        min-width: 0;
+    }
+
+    .session-overview::-webkit-scrollbar {
+        display: none;
     }
 
     .summary-card {
@@ -152,6 +164,7 @@
         flex-wrap: nowrap;
         overflow-x: auto;
         scrollbar-width: none;
+        width: 100%;
     }
 
     .stats-tab-nav::-webkit-scrollbar {
@@ -159,7 +172,7 @@
     }
 
     .stats-tab-button {
-        flex: 1 1 auto;
+        flex: 1 1 0;
         border: none;
         background: transparent;
         border-radius: 999px;
@@ -580,6 +593,13 @@
         border-top: 1px solid #e2e8f0;
         padding-top: 1rem;
         margin-top: 0.5rem;
+        margin-bottom: 0.75rem;
+    }
+
+    .card-info-section:first-child {
+        border-top: none;
+        padding-top: 0;
+        margin-top: 0;
     }
 
     .card-info-title {
@@ -590,11 +610,20 @@
         cursor: pointer;
         user-select: none;
         font-size: 0.9rem;
+        background: rgba(37, 99, 235, 0.08);
+        padding: 0.65rem 0.85rem;
+        border-radius: 12px;
+        transition: background 0.2s ease, color 0.2s ease;
     }
 
     .card-info-title i {
         margin-right: 0.5rem;
         transition: transform 0.2s ease;
+    }
+
+    .card-info-title:hover {
+        background: rgba(37, 99, 235, 0.15);
+        color: #1d4ed8;
     }
 
     .card-info-title.collapsed i {
@@ -695,14 +724,14 @@
 
     @media (max-width: 640px) {
         .session-overview {
-            grid-template-columns: 1fr;
+            flex-wrap: nowrap;
         }
         .stats-tab-nav {
             padding: 0.3rem;
             justify-content: space-between;
         }
         .stats-tab-button {
-            flex: 0 0 auto;
+            flex: 1 1 0;
             font-size: 0.8rem;
             padding: 0.45rem 0.65rem;
         }

--- a/mindstack_app/modules/learning/flashcard_learning/templates/flashcard_session.html
+++ b/mindstack_app/modules/learning/flashcard_learning/templates/flashcard_session.html
@@ -1712,16 +1712,16 @@
                     <p><span class="label">Mặt sau</span>${formatTextForHtml(cardContent.back)}</p>
                 </div>
             </div>
-        ` : '';
+        `.trim() : '';
 
-        return `
-            ${introNotice}
-            ${progressSection}
-            ${insightSection}
-            ${recentSection}
-            ${timelineSection}
-            ${cardDetails}
-        `;
+        return [
+            cardDetails,
+            introNotice,
+            progressSection,
+            insightSection,
+            recentSection,
+            timelineSection
+        ].join('');
     }
 
     function initializeStatsToggleListeners(rootElement) {


### PR DESCRIPTION
## Summary
- keep the flashcard session summary cards on a single horizontal row with responsive scrolling support
- force the statistics tab buttons to span the full width and refresh the card detail toggle styling
- move the "Chi tiết thẻ" toggle directly under the tab strip within the stats panes

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d50ed402348326b050cb2500702846