### PR TITLE
Fix desktop stats panel layout

### DIFF
--- a/mindstack_app/modules/learning/flashcard_learning/templates/flashcard_session.html
+++ b/mindstack_app/modules/learning/flashcard_learning/templates/flashcard_session.html
@@ -682,7 +682,7 @@
             height: 100%;
             min-height: 0;
             overflow-y: auto;
-            width: 500px;
+            width: min(100%, 520px);
         }
     }
 


### PR DESCRIPTION
## Summary
- constrain the desktop statistics card width using a responsive value so it fits within the session layout column on smaller desktops

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5447278e083269eb23ef327c6c2b4