### PR TITLE
Fix flashcard stats layout on desktop

### DIFF
--- a/mindstack_app/modules/learning/flashcard_learning/templates/_flashcard_session_stats.html
+++ b/mindstack_app/modules/learning/flashcard_learning/templates/_flashcard_session_stats.html
@@ -95,6 +95,7 @@
         flex-wrap: nowrap;
         overflow-x: auto;
         scrollbar-width: none;
+        flex-shrink: 0;
     }
 
     .session-overview > * {
@@ -177,6 +178,7 @@
         overflow-x: auto;
         scrollbar-width: none;
         width: 100%;
+        flex-shrink: 0;
     }
 
     .stats-tab-nav::-webkit-scrollbar {


### PR DESCRIPTION
## Summary
- prevent the flashcard stats session overview and tab controls from shrinking in the desktop sidebar
- ensure these sections remain visible by disabling flex shrinking on their wrappers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5467466888326aefec76f15e2e369