### PR TITLE
Add per-set stats API and UI to dashboard

### DIFF
--- a/mindstack_app/modules/stats/templates/statistics.html
+++ b/mindstack_app/modules/stats/templates/statistics.html
@@ -56,6 +56,23 @@
         .stat-card-icon.sets { background-color: #dbeafe; color: #3b82f6; }
         .stat-card-value { font-size: 1.5rem; font-weight: 700; color: var(--text-primary); }
         .stat-card-label { font-size: 0.875rem; color: var(--text-secondary); }
+
+        .stat-detail-section { margin-top: 1.75rem; border-top: 1px solid var(--border-color); padding-top: 1.5rem; }
+        .stat-detail-header { display: flex; align-items: center; justify-content: space-between; gap: 1rem; flex-wrap: wrap; }
+        .stat-detail-header label { font-weight: 600; color: var(--text-primary); }
+        .stat-detail-select { min-width: 220px; padding: 0.5rem 0.75rem; border: 1px solid var(--border-color); border-radius: 0.375rem; background-color: #f9fafb; }
+        .stat-detail-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 1rem; margin-top: 1rem; }
+        .stat-detail-card { background-color: #f9fafb; border: 1px solid var(--border-color); border-radius: 0.5rem; padding: 1rem; }
+        .stat-detail-label { display: block; font-size: 0.75rem; font-weight: 600; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.03em; margin-bottom: 0.35rem; }
+        .stat-detail-value { font-size: 1.25rem; font-weight: 700; color: var(--text-primary); }
+        .stat-detail-note { margin-top: 1rem; font-size: 0.875rem; color: var(--text-secondary); }
+        .stat-detail-list-container { margin-top: 1.25rem; }
+        .stat-detail-subtitle { font-size: 1rem; font-weight: 600; color: var(--text-primary); margin-bottom: 0.75rem; }
+        .stat-detail-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.75rem; }
+        .stat-detail-list-item { padding: 0.75rem; border: 1px solid var(--border-color); border-radius: 0.5rem; background-color: #f9fafb; }
+        .stat-detail-list-item strong { display: block; color: var(--text-primary); margin-bottom: 0.35rem; }
+        .stat-detail-list-item span { display: block; color: var(--text-secondary); font-size: 0.875rem; }
+        .stat-detail-meta { display: block; font-size: 0.75rem; color: var(--text-secondary); margin-top: 0.35rem; }
     </style>
 {% endblock %}
 
@@ -76,9 +93,9 @@
             </div>
             <div class="form-group timeframe-group">
                 <div class="timeframe-tabs">
-                    <button type="button" class="tab-button" data-timeframe="day">Hôm nay</button>
-                    <button type="button" class="tab-button" data-timeframe="week">Tuần này</button>
-                    <button type="button" class="tab-button" data-timeframe="month">Tháng này</button>
+                    <button type="button" class="tab-button {% if current_timeframe == 'day' %}active{% endif %}" data-timeframe="day">Hôm nay</button>
+                    <button type="button" class="tab-button {% if current_timeframe == 'week' %}active{% endif %}" data-timeframe="week">Tuần này</button>
+                    <button type="button" class="tab-button {% if current_timeframe == 'month' %}active{% endif %}" data-timeframe="month">Tháng này</button>
                     <button type="button" class="tab-button {% if current_timeframe == 'all_time' %}active{% endif %}" data-timeframe="all_time">Toàn bộ</button>
                 </div>
             </div>
@@ -122,6 +139,54 @@
                         </div>
                     </div>
                 </div>
+                <div class="stat-detail-section">
+                    <div class="stat-detail-header">
+                        <label for="flashcard-set-select">Chi tiết theo bộ</label>
+                        <select id="flashcard-set-select" class="stat-detail-select" data-has-options="{{ 'true' if flashcard_sets else 'false' }}" {% if not flashcard_sets %}disabled{% endif %}>
+                            {% if flashcard_sets %}
+                                {% for flashcard_set in flashcard_sets %}
+                                    <option value="{{ flashcard_set.id }}" {% if loop.first %}selected{% endif %}>{{ flashcard_set.title }}</option>
+                                {% endfor %}
+                            {% else %}
+                                <option value="">Chưa có bộ Flashcard nào</option>
+                            {% endif %}
+                        </select>
+                    </div>
+                    <div class="loader-container" id="flashcard-detail-loader" style="display: none;">
+                        <div class="loader"></div>
+                    </div>
+                    <p class="empty-message" id="flashcard-detail-empty" style="display: {{ 'none' if flashcard_sets else 'block' }};">Bạn chưa có bộ Flashcard nào đang học.</p>
+                    <div class="stat-detail-grid" id="flashcard-detail-metrics" style="display: none;">
+                        <div class="stat-detail-card">
+                            <span class="stat-detail-label">Tổng số thẻ</span>
+                            <span class="stat-detail-value" data-flashcard-metric="total_cards">0</span>
+                        </div>
+                        <div class="stat-detail-card">
+                            <span class="stat-detail-label">Đã ôn tập</span>
+                            <span class="stat-detail-value" data-flashcard-metric="studied_cards">0</span>
+                        </div>
+                        <div class="stat-detail-card">
+                            <span class="stat-detail-label">Thẻ thành thạo</span>
+                            <span class="stat-detail-value" data-flashcard-metric="learned_cards">0</span>
+                        </div>
+                        <div class="stat-detail-card">
+                            <span class="stat-detail-label">Độ chính xác</span>
+                            <span class="stat-detail-value" data-flashcard-metric="accuracy">--</span>
+                        </div>
+                        <div class="stat-detail-card">
+                            <span class="stat-detail-label">Chuỗi đúng TB</span>
+                            <span class="stat-detail-value" data-flashcard-metric="avg_streak">0</span>
+                        </div>
+                        <div class="stat-detail-card">
+                            <span class="stat-detail-label">Chuỗi đúng tốt nhất</span>
+                            <span class="stat-detail-value" data-flashcard-metric="best_streak">0</span>
+                        </div>
+                    </div>
+                    <div class="stat-detail-list-container" id="flashcard-learned-container" style="display: none;">
+                        <h4 class="stat-detail-subtitle">Thẻ thành thạo gần đây</h4>
+                        <ul class="stat-detail-list" id="flashcard-learned-list"></ul>
+                    </div>
+                </div>
             </div>
         </div>
 
@@ -151,6 +216,54 @@
                         </div>
                     </div>
                 </div>
+                <div class="stat-detail-section">
+                    <div class="stat-detail-header">
+                        <label for="quiz-set-select">Chi tiết theo bộ</label>
+                        <select id="quiz-set-select" class="stat-detail-select" data-has-options="{{ 'true' if quiz_sets else 'false' }}" {% if not quiz_sets %}disabled{% endif %}>
+                            {% if quiz_sets %}
+                                {% for quiz_set in quiz_sets %}
+                                    <option value="{{ quiz_set.id }}" {% if loop.first %}selected{% endif %}>{{ quiz_set.title }}</option>
+                                {% endfor %}
+                            {% else %}
+                                <option value="">Chưa có bộ Trắc nghiệm nào</option>
+                            {% endif %}
+                        </select>
+                    </div>
+                    <div class="loader-container" id="quiz-detail-loader" style="display: none;">
+                        <div class="loader"></div>
+                    </div>
+                    <p class="empty-message" id="quiz-detail-empty" style="display: {{ 'none' if quiz_sets else 'block' }};">Bạn chưa có bộ Trắc nghiệm nào đang làm.</p>
+                    <div class="stat-detail-grid" id="quiz-detail-metrics" style="display: none;">
+                        <div class="stat-detail-card">
+                            <span class="stat-detail-label">Tổng số câu hỏi</span>
+                            <span class="stat-detail-value" data-quiz-metric="total_questions">0</span>
+                        </div>
+                        <div class="stat-detail-card">
+                            <span class="stat-detail-label">Đã trả lời</span>
+                            <span class="stat-detail-value" data-quiz-metric="attempted_questions">0</span>
+                        </div>
+                        <div class="stat-detail-card">
+                            <span class="stat-detail-label">Trả lời đúng</span>
+                            <span class="stat-detail-value" data-quiz-metric="total_correct">0</span>
+                        </div>
+                        <div class="stat-detail-card">
+                            <span class="stat-detail-label">Độ chính xác</span>
+                            <span class="stat-detail-value" data-quiz-metric="accuracy">--</span>
+                        </div>
+                        <div class="stat-detail-card">
+                            <span class="stat-detail-label">Chuỗi đúng TB</span>
+                            <span class="stat-detail-value" data-quiz-metric="avg_streak">0</span>
+                        </div>
+                        <div class="stat-detail-card">
+                            <span class="stat-detail-label">Chuỗi đúng tốt nhất</span>
+                            <span class="stat-detail-value" data-quiz-metric="best_streak">0</span>
+                        </div>
+                    </div>
+                    <div class="stat-detail-list-container" id="quiz-correct-container" style="display: none;">
+                        <h4 class="stat-detail-subtitle">Câu trả lời đúng gần đây</h4>
+                        <ul class="stat-detail-list" id="quiz-correct-list"></ul>
+                    </div>
+                </div>
             </div>
         </div>
 
@@ -171,6 +284,47 @@
                             <span class="stat-card-value">{{ dashboard_data.courses_started_count }}</span>
                             <span class="stat-card-label">Khoá học đã bắt đầu</span>
                         </div>
+                    </div>
+                </div>
+                <div class="stat-detail-section">
+                    <div class="stat-detail-header">
+                        <label for="course-set-select">Chi tiết theo khoá học</label>
+                        <select id="course-set-select" class="stat-detail-select" data-has-options="{{ 'true' if course_sets else 'false' }}" {% if not course_sets %}disabled{% endif %}>
+                            {% if course_sets %}
+                                {% for course_set in course_sets %}
+                                    <option value="{{ course_set.id }}" {% if loop.first %}selected{% endif %}>{{ course_set.title }}</option>
+                                {% endfor %}
+                            {% else %}
+                                <option value="">Chưa có khoá học nào</option>
+                            {% endif %}
+                        </select>
+                    </div>
+                    <div class="loader-container" id="course-detail-loader" style="display: none;">
+                        <div class="loader"></div>
+                    </div>
+                    <p class="empty-message" id="course-detail-empty" style="display: {{ 'none' if course_sets else 'block' }};">Bạn chưa bắt đầu khoá học nào.</p>
+                    <div class="stat-detail-grid" id="course-detail-metrics" style="display: none;">
+                        <div class="stat-detail-card">
+                            <span class="stat-detail-label">Tổng số bài học</span>
+                            <span class="stat-detail-value" data-course-metric="total_lessons">0</span>
+                        </div>
+                        <div class="stat-detail-card">
+                            <span class="stat-detail-label">Đã mở</span>
+                            <span class="stat-detail-value" data-course-metric="lessons_started">0</span>
+                        </div>
+                        <div class="stat-detail-card">
+                            <span class="stat-detail-label">Hoàn thành</span>
+                            <span class="stat-detail-value" data-course-metric="lessons_completed">0</span>
+                        </div>
+                        <div class="stat-detail-card">
+                            <span class="stat-detail-label">Hoàn thành trung bình</span>
+                            <span class="stat-detail-value" data-course-metric="avg_completion">--</span>
+                        </div>
+                    </div>
+                    <p class="stat-detail-note" id="course-detail-note" style="display: none;">Hoạt động gần nhất: <span data-course-metric="last_activity">--</span></p>
+                    <div class="stat-detail-list-container" id="course-recent-container" style="display: none;">
+                        <h4 class="stat-detail-subtitle">Bài học gần đây</h4>
+                        <ul class="stat-detail-list" id="course-recent-list"></ul>
                     </div>
                 </div>
             </div>
@@ -200,11 +354,13 @@
             const emptyMessage = document.getElementById('leaderboard-empty-message');
 
             function fetchAndUpdateLeaderboard() {
-                const timeframe = timeframeTabs.querySelector('.tab-button.active').dataset.timeframe;
-                const sortBy = sortBySelect.value;
+                if (!timeframeTabs) return;
+                const activeTab = timeframeTabs.querySelector('.tab-button.active');
+                const timeframe = activeTab ? activeTab.dataset.timeframe : 'all_time';
+                const sortBy = sortBySelect ? sortBySelect.value : 'total_score';
 
-                loader.style.display = 'flex';
-                listContainer.style.display = 'none';
+                if (loader) loader.style.display = 'flex';
+                if (listContainer) listContainer.style.display = 'none';
                 if (emptyMessage) emptyMessage.style.display = 'none';
 
                 const apiUrl = `{{ url_for('stats.get_leaderboard_data_api') }}?sort_by=${sortBy}&timeframe=${timeframe}`;
@@ -213,17 +369,18 @@
                     .then(response => response.json())
                     .then(result => {
                         if (result.success) {
-                            renderLeaderboard(result.data, sortBy);
+                            renderLeaderboard(result.data);
                         }
                     })
                     .catch(error => console.error('Lỗi fetch leaderboard:', error))
                     .finally(() => {
-                        loader.style.display = 'none';
+                        if (loader) loader.style.display = 'none';
                     });
             }
 
-            function renderLeaderboard(data, sortBy) {
-                listContainer.innerHTML = ''; 
+            function renderLeaderboard(data) {
+                if (!listContainer) return;
+                listContainer.innerHTML = '';
                 if (data && data.length > 0) {
                     if (emptyMessage) emptyMessage.style.display = 'none';
                     listContainer.style.display = 'block';
@@ -232,7 +389,7 @@
                     data.forEach((entry, index) => {
                         const clone = template.content.cloneNode(true);
                         const rankSpan = clone.querySelector('.rank');
-                        
+
                         if (index === 0) rankSpan.innerHTML = '<i class="fas fa-medal gold-medal"></i>';
                         else if (index === 1) rankSpan.innerHTML = '<i class="fas fa-medal silver-medal"></i>';
                         else if (index === 2) rankSpan.innerHTML = '<i class="fas fa-medal bronze-medal"></i>';
@@ -242,7 +399,7 @@
                         const usernameElement = clone.querySelector('.username');
                         usernameElement.textContent = usernameText;
                         clone.querySelector('.score-value').textContent = `${entry.current_period_score} điểm`;
-                        
+
                         listContainer.appendChild(clone);
                     });
                 } else {
@@ -251,15 +408,387 @@
                 }
             }
 
-            timeframeTabs.addEventListener('click', function(event) {
-                if (event.target.tagName === 'BUTTON' && !event.target.classList.contains('active')) {
-                    timeframeTabs.querySelector('.tab-button.active').classList.remove('active');
-                    event.target.classList.add('active');
-                    fetchAndUpdateLeaderboard();
-                }
-            });
+            if (timeframeTabs) {
+                timeframeTabs.addEventListener('click', function(event) {
+                    if (event.target.tagName === 'BUTTON') {
+                        const previouslyActive = timeframeTabs.querySelector('.tab-button.active');
+                        if (previouslyActive !== event.target) {
+                            if (previouslyActive) previouslyActive.classList.remove('active');
+                            event.target.classList.add('active');
+                            fetchAndUpdateLeaderboard();
+                        }
+                    }
+                });
+            }
 
-            sortBySelect.addEventListener('change', fetchAndUpdateLeaderboard);
+            if (sortBySelect) {
+                sortBySelect.addEventListener('change', fetchAndUpdateLeaderboard);
+            }
+
+            const flashcardEndpoint = "{{ url_for('stats.get_flashcard_set_metrics_api') }}";
+            const quizEndpoint = "{{ url_for('stats.get_quiz_set_metrics_api') }}";
+            const courseEndpoint = "{{ url_for('stats.get_course_metrics_api') }}";
+
+            const numberFormatter = new Intl.NumberFormat('vi-VN');
+
+            function formatNumber(value) {
+                if (value === null || value === undefined) return '0';
+                const numeric = Number(value);
+                if (Number.isNaN(numeric)) return '0';
+                return numberFormatter.format(numeric);
+            }
+
+            function formatPercent(value) {
+                if (value === null || value === undefined) return '--';
+                const numeric = Number(value);
+                if (Number.isNaN(numeric)) return '--';
+                return `${numeric.toFixed(1)}%`;
+            }
+
+            function formatDateTime(value) {
+                if (!value) return '--';
+                const dateValue = new Date(value);
+                if (Number.isNaN(dateValue.getTime())) return '--';
+                return dateValue.toLocaleString('vi-VN');
+            }
+
+            function setupFlashcardMetrics() {
+                const select = document.getElementById('flashcard-set-select');
+                if (!select) return;
+                const hasOptions = select.dataset.hasOptions === 'true';
+                const loaderEl = document.getElementById('flashcard-detail-loader');
+                const emptyEl = document.getElementById('flashcard-detail-empty');
+                const metricsGrid = document.getElementById('flashcard-detail-metrics');
+                const listWrapper = document.getElementById('flashcard-learned-container');
+                const listEl = document.getElementById('flashcard-learned-list');
+                const fields = {
+                    total_cards: metricsGrid ? metricsGrid.querySelector('[data-flashcard-metric="total_cards"]') : null,
+                    studied_cards: metricsGrid ? metricsGrid.querySelector('[data-flashcard-metric="studied_cards"]') : null,
+                    learned_cards: metricsGrid ? metricsGrid.querySelector('[data-flashcard-metric="learned_cards"]') : null,
+                    accuracy: metricsGrid ? metricsGrid.querySelector('[data-flashcard-metric="accuracy"]') : null,
+                    avg_streak: metricsGrid ? metricsGrid.querySelector('[data-flashcard-metric="avg_streak"]') : null,
+                    best_streak: metricsGrid ? metricsGrid.querySelector('[data-flashcard-metric="best_streak"]') : null,
+                };
+
+                function showEmpty(message) {
+                    if (emptyEl) {
+                        emptyEl.textContent = message;
+                        emptyEl.style.display = 'block';
+                    }
+                    if (metricsGrid) metricsGrid.style.display = 'none';
+                    if (listWrapper) listWrapper.style.display = 'none';
+                }
+
+                function render(data) {
+                    if (!data) {
+                        showEmpty('Không tìm thấy dữ liệu cho bộ đã chọn.');
+                        return;
+                    }
+
+                    if (fields.total_cards) fields.total_cards.textContent = formatNumber(data.total_cards);
+                    if (fields.studied_cards) fields.studied_cards.textContent = formatNumber(data.studied_cards);
+                    if (fields.learned_cards) fields.learned_cards.textContent = formatNumber(data.learned_cards);
+                    if (fields.accuracy) fields.accuracy.textContent = data.accuracy_percent !== null ? formatPercent(data.accuracy_percent) : '--';
+                    if (fields.avg_streak) {
+                        const avg = data.avg_correct_streak !== null && data.avg_correct_streak !== undefined ? Number(data.avg_correct_streak) : 0;
+                        fields.avg_streak.textContent = avg.toFixed(1);
+                    }
+                    if (fields.best_streak) fields.best_streak.textContent = formatNumber(data.best_correct_streak);
+
+                    if (metricsGrid) metricsGrid.style.display = 'grid';
+
+                    if (listWrapper && listEl) {
+                        listEl.innerHTML = '';
+                        const examples = Array.isArray(data.learned_examples) ? data.learned_examples : [];
+                        if (examples.length > 0) {
+                            examples.forEach(example => {
+                                const li = document.createElement('li');
+                                li.className = 'stat-detail-list-item';
+                                const titleText = example.front || `Thẻ #${example.item_id}`;
+                                const backText = example.back ? `<span>${example.back}</span>` : '';
+                                const timestamp = example.last_reviewed || example.first_seen;
+                                const metaText = timestamp ? `<span class="stat-detail-meta">Ôn gần nhất: ${formatDateTime(timestamp)}</span>` : '';
+                                li.innerHTML = `<strong>${titleText}</strong>${backText}${metaText}`;
+                                listEl.appendChild(li);
+                            });
+                            listWrapper.style.display = 'block';
+                        } else {
+                            listWrapper.style.display = 'none';
+                        }
+                    }
+
+                    if (emptyEl) emptyEl.style.display = 'none';
+                }
+
+                function load(containerId) {
+                    if (!containerId) {
+                        showEmpty('Hãy chọn một bộ Flashcard để xem chi tiết.');
+                        return;
+                    }
+
+                    if (loaderEl) loaderEl.style.display = 'flex';
+                    if (metricsGrid) metricsGrid.style.display = 'none';
+                    if (listWrapper) listWrapper.style.display = 'none';
+                    if (emptyEl) emptyEl.style.display = 'none';
+
+                    fetch(`${flashcardEndpoint}?container_id=${containerId}`)
+                        .then(response => response.json())
+                        .then(result => {
+                            if (result.success) {
+                                const payload = result.data ? (result.data[String(containerId)] || result.data[Object.keys(result.data)[0]]) : null;
+                                render(payload);
+                            } else {
+                                showEmpty('Không thể tải dữ liệu chi tiết.');
+                            }
+                        })
+                        .catch(() => showEmpty('Không thể tải dữ liệu chi tiết.'))
+                        .finally(() => {
+                            if (loaderEl) loaderEl.style.display = 'none';
+                        });
+                }
+
+                if (!hasOptions) {
+                    showEmpty('Bạn chưa có bộ Flashcard nào đang học.');
+                    return;
+                }
+
+                select.addEventListener('change', event => load(event.target.value));
+
+                const initialId = select.value;
+                if (initialId) {
+                    load(initialId);
+                } else {
+                    showEmpty('Hãy chọn một bộ Flashcard để xem chi tiết.');
+                }
+            }
+
+            function setupQuizMetrics() {
+                const select = document.getElementById('quiz-set-select');
+                if (!select) return;
+                const hasOptions = select.dataset.hasOptions === 'true';
+                const loaderEl = document.getElementById('quiz-detail-loader');
+                const emptyEl = document.getElementById('quiz-detail-empty');
+                const metricsGrid = document.getElementById('quiz-detail-metrics');
+                const listWrapper = document.getElementById('quiz-correct-container');
+                const listEl = document.getElementById('quiz-correct-list');
+                const fields = {
+                    total_questions: metricsGrid ? metricsGrid.querySelector('[data-quiz-metric="total_questions"]') : null,
+                    attempted_questions: metricsGrid ? metricsGrid.querySelector('[data-quiz-metric="attempted_questions"]') : null,
+                    total_correct: metricsGrid ? metricsGrid.querySelector('[data-quiz-metric="total_correct"]') : null,
+                    accuracy: metricsGrid ? metricsGrid.querySelector('[data-quiz-metric="accuracy"]') : null,
+                    avg_streak: metricsGrid ? metricsGrid.querySelector('[data-quiz-metric="avg_streak"]') : null,
+                    best_streak: metricsGrid ? metricsGrid.querySelector('[data-quiz-metric="best_streak"]') : null,
+                };
+
+                function showEmpty(message) {
+                    if (emptyEl) {
+                        emptyEl.textContent = message;
+                        emptyEl.style.display = 'block';
+                    }
+                    if (metricsGrid) metricsGrid.style.display = 'none';
+                    if (listWrapper) listWrapper.style.display = 'none';
+                }
+
+                function render(data) {
+                    if (!data) {
+                        showEmpty('Không tìm thấy dữ liệu cho bộ đã chọn.');
+                        return;
+                    }
+
+                    if (fields.total_questions) fields.total_questions.textContent = formatNumber(data.total_questions);
+                    if (fields.attempted_questions) fields.attempted_questions.textContent = formatNumber(data.attempted_questions);
+                    if (fields.total_correct) fields.total_correct.textContent = formatNumber(data.total_correct);
+                    if (fields.accuracy) fields.accuracy.textContent = data.accuracy_percent !== null ? formatPercent(data.accuracy_percent) : '--';
+                    if (fields.avg_streak) {
+                        const avg = data.avg_correct_streak !== null && data.avg_correct_streak !== undefined ? Number(data.avg_correct_streak) : 0;
+                        fields.avg_streak.textContent = avg.toFixed(1);
+                    }
+                    if (fields.best_streak) fields.best_streak.textContent = formatNumber(data.best_correct_streak);
+
+                    if (metricsGrid) metricsGrid.style.display = 'grid';
+
+                    if (listWrapper && listEl) {
+                        listEl.innerHTML = '';
+                        const examples = Array.isArray(data.correct_examples) ? data.correct_examples : [];
+                        if (examples.length > 0) {
+                            examples.forEach(example => {
+                                const li = document.createElement('li');
+                                li.className = 'stat-detail-list-item';
+                                const titleText = example.question || `Câu hỏi #${example.item_id}`;
+                                const statsText = `<span>Đúng ${formatNumber(example.times_correct)} - Sai ${formatNumber(example.times_incorrect)}</span>`;
+                                const metaText = example.last_reviewed ? `<span class="stat-detail-meta">Lần gần nhất: ${formatDateTime(example.last_reviewed)}</span>` : '';
+                                li.innerHTML = `<strong>${titleText}</strong>${statsText}${metaText}`;
+                                listEl.appendChild(li);
+                            });
+                            listWrapper.style.display = 'block';
+                        } else {
+                            listWrapper.style.display = 'none';
+                        }
+                    }
+
+                    if (emptyEl) emptyEl.style.display = 'none';
+                }
+
+                function load(containerId) {
+                    if (!containerId) {
+                        showEmpty('Hãy chọn một bộ Trắc nghiệm để xem chi tiết.');
+                        return;
+                    }
+
+                    if (loaderEl) loaderEl.style.display = 'flex';
+                    if (metricsGrid) metricsGrid.style.display = 'none';
+                    if (listWrapper) listWrapper.style.display = 'none';
+                    if (emptyEl) emptyEl.style.display = 'none';
+
+                    fetch(`${quizEndpoint}?container_id=${containerId}`)
+                        .then(response => response.json())
+                        .then(result => {
+                            if (result.success) {
+                                const payload = result.data ? (result.data[String(containerId)] || result.data[Object.keys(result.data)[0]]) : null;
+                                render(payload);
+                            } else {
+                                showEmpty('Không thể tải dữ liệu chi tiết.');
+                            }
+                        })
+                        .catch(() => showEmpty('Không thể tải dữ liệu chi tiết.'))
+                        .finally(() => {
+                            if (loaderEl) loaderEl.style.display = 'none';
+                        });
+                }
+
+                if (!hasOptions) {
+                    showEmpty('Bạn chưa có bộ Trắc nghiệm nào đang làm.');
+                    return;
+                }
+
+                select.addEventListener('change', event => load(event.target.value));
+
+                const initialId = select.value;
+                if (initialId) {
+                    load(initialId);
+                } else {
+                    showEmpty('Hãy chọn một bộ Trắc nghiệm để xem chi tiết.');
+                }
+            }
+
+            function setupCourseMetrics() {
+                const select = document.getElementById('course-set-select');
+                if (!select) return;
+                const hasOptions = select.dataset.hasOptions === 'true';
+                const loaderEl = document.getElementById('course-detail-loader');
+                const emptyEl = document.getElementById('course-detail-empty');
+                const metricsGrid = document.getElementById('course-detail-metrics');
+                const noteEl = document.getElementById('course-detail-note');
+                const lastActivityField = noteEl ? noteEl.querySelector('[data-course-metric="last_activity"]') : null;
+                const listWrapper = document.getElementById('course-recent-container');
+                const listEl = document.getElementById('course-recent-list');
+                const fields = {
+                    total_lessons: metricsGrid ? metricsGrid.querySelector('[data-course-metric="total_lessons"]') : null,
+                    lessons_started: metricsGrid ? metricsGrid.querySelector('[data-course-metric="lessons_started"]') : null,
+                    lessons_completed: metricsGrid ? metricsGrid.querySelector('[data-course-metric="lessons_completed"]') : null,
+                    avg_completion: metricsGrid ? metricsGrid.querySelector('[data-course-metric="avg_completion"]') : null,
+                };
+
+                function showEmpty(message) {
+                    if (emptyEl) {
+                        emptyEl.textContent = message;
+                        emptyEl.style.display = 'block';
+                    }
+                    if (metricsGrid) metricsGrid.style.display = 'none';
+                    if (noteEl) noteEl.style.display = 'none';
+                    if (listWrapper) listWrapper.style.display = 'none';
+                }
+
+                function render(data) {
+                    if (!data) {
+                        showEmpty('Không tìm thấy dữ liệu cho khoá học đã chọn.');
+                        return;
+                    }
+
+                    if (fields.total_lessons) fields.total_lessons.textContent = formatNumber(data.total_lessons);
+                    if (fields.lessons_started) fields.lessons_started.textContent = formatNumber(data.lessons_started);
+                    if (fields.lessons_completed) fields.lessons_completed.textContent = formatNumber(data.lessons_completed);
+                    if (fields.avg_completion) fields.avg_completion.textContent = formatPercent(data.avg_completion_percent);
+
+                    if (metricsGrid) metricsGrid.style.display = 'grid';
+
+                    if (noteEl && lastActivityField) {
+                        if (data.last_activity) {
+                            lastActivityField.textContent = formatDateTime(data.last_activity);
+                            noteEl.style.display = 'block';
+                        } else {
+                            noteEl.style.display = 'none';
+                        }
+                    }
+
+                    if (listWrapper && listEl) {
+                        listEl.innerHTML = '';
+                        const lessons = Array.isArray(data.recent_lessons) ? data.recent_lessons : [];
+                        if (lessons.length > 0) {
+                            lessons.forEach(lesson => {
+                                const li = document.createElement('li');
+                                li.className = 'stat-detail-list-item';
+                                const titleText = lesson.title || `Bài học #${lesson.item_id}`;
+                                const progressText = `<span>Hoàn thành: ${formatNumber(lesson.completion_percentage)}%</span>`;
+                                const metaText = lesson.last_updated ? `<span class="stat-detail-meta">Cập nhật: ${formatDateTime(lesson.last_updated)}</span>` : '';
+                                li.innerHTML = `<strong>${titleText}</strong>${progressText}${metaText}`;
+                                listEl.appendChild(li);
+                            });
+                            listWrapper.style.display = 'block';
+                        } else {
+                            listWrapper.style.display = 'none';
+                        }
+                    }
+
+                    if (emptyEl) emptyEl.style.display = 'none';
+                }
+
+                function load(containerId) {
+                    if (!containerId) {
+                        showEmpty('Hãy chọn một khoá học để xem chi tiết.');
+                        return;
+                    }
+
+                    if (loaderEl) loaderEl.style.display = 'flex';
+                    if (metricsGrid) metricsGrid.style.display = 'none';
+                    if (listWrapper) listWrapper.style.display = 'none';
+                    if (noteEl) noteEl.style.display = 'none';
+                    if (emptyEl) emptyEl.style.display = 'none';
+
+                    fetch(`${courseEndpoint}?container_id=${containerId}`)
+                        .then(response => response.json())
+                        .then(result => {
+                            if (result.success) {
+                                const payload = result.data ? (result.data[String(containerId)] || result.data[Object.keys(result.data)[0]]) : null;
+                                render(payload);
+                            } else {
+                                showEmpty('Không thể tải dữ liệu chi tiết.');
+                            }
+                        })
+                        .catch(() => showEmpty('Không thể tải dữ liệu chi tiết.'))
+                        .finally(() => {
+                            if (loaderEl) loaderEl.style.display = 'none';
+                        });
+                }
+
+                if (!hasOptions) {
+                    showEmpty('Bạn chưa bắt đầu khoá học nào.');
+                    return;
+                }
+
+                select.addEventListener('change', event => load(event.target.value));
+
+                const initialId = select.value;
+                if (initialId) {
+                    load(initialId);
+                } else {
+                    showEmpty('Hãy chọn một khoá học để xem chi tiết.');
+                }
+            }
+
+            setupFlashcardMetrics();
+            setupQuizMetrics();
+            setupCourseMetrics();
         });
     </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add helper aggregation functions and per-container metrics APIs for flashcards, quizzes, and courses in the stats module
- enrich the dashboard route with available learning sets for the current user and expose new metrics endpoints
- update the statistics template with dropdown controls, dynamic loaders, and client-side rendering of per-set metrics

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6914b75948326a65b53440a85d23a