### PR TITLE
Add flashcard/quiz/course activity endpoints and charts

### DIFF
--- a/mindstack_app/modules/stats/templates/statistics.html
+++ b/mindstack_app/modules/stats/templates/statistics.html
@@ -93,6 +93,15 @@
         .stats-modal-page-btn[disabled] { opacity: 0.5; cursor: not-allowed; }
         .stats-modal-page-label { font-size: 0.9rem; color: var(--text-secondary); }
 
+        /* Activity charts */
+        .stat-chart-section { margin-top: 1.75rem; border-top: 1px solid var(--border-color); padding-top: 1.5rem; }
+        .stat-chart-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.75rem; gap: 0.75rem; }
+        .stat-chart-title { font-size: 1rem; font-weight: 600; color: var(--text-primary); }
+        .stat-chart-range { padding: 0.4rem 0.65rem; border: 1px solid var(--border-color); border-radius: 0.375rem; background-color: #f9fafb; color: var(--text-primary); font-size: 0.875rem; }
+        .stat-chart-body { position: relative; min-height: 220px; }
+        .stat-chart-body canvas { width: 100%; height: 220px; }
+        .stat-chart-empty { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; color: var(--text-secondary); text-align: center; padding: 1rem; }
+
         @media (max-width: 640px) {
             .stats-modal-dialog { width: 96%; }
             .stats-modal-header, .stats-modal-body, .stats-modal-pagination { padding-left: 1.25rem; padding-right: 1.25rem; }
@@ -211,6 +220,25 @@
                         <ul class="stat-detail-list" id="flashcard-learned-list"></ul>
                     </div>
                 </div>
+                <div class="stat-chart-section">
+                    <div class="stat-chart-header">
+                        <span class="stat-chart-title">Hoạt động gần đây</span>
+                        <select id="flashcard-chart-range" class="stat-chart-range">
+                            <option value="7d">7 ngày</option>
+                            <option value="30d" selected>30 ngày</option>
+                            <option value="90d">90 ngày</option>
+                            <option value="365d">365 ngày</option>
+                            <option value="all">Toàn bộ</option>
+                        </select>
+                    </div>
+                    <div class="stat-chart-body">
+                        <div class="loader-container" id="flashcard-chart-loader" style="display: none;">
+                            <div class="loader"></div>
+                        </div>
+                        <p class="stat-chart-empty" id="flashcard-chart-empty" style="display: none;">Chọn một bộ để xem hoạt động.</p>
+                        <canvas id="flashcard-activity-chart" aria-label="Biểu đồ hoạt động flashcard"></canvas>
+                    </div>
+                </div>
             </div>
         </div>
 
@@ -288,6 +316,25 @@
                         <ul class="stat-detail-list" id="quiz-correct-list"></ul>
                     </div>
                 </div>
+                <div class="stat-chart-section">
+                    <div class="stat-chart-header">
+                        <span class="stat-chart-title">Hoạt động gần đây</span>
+                        <select id="quiz-chart-range" class="stat-chart-range">
+                            <option value="7d">7 ngày</option>
+                            <option value="30d" selected>30 ngày</option>
+                            <option value="90d">90 ngày</option>
+                            <option value="365d">365 ngày</option>
+                            <option value="all">Toàn bộ</option>
+                        </select>
+                    </div>
+                    <div class="stat-chart-body">
+                        <div class="loader-container" id="quiz-chart-loader" style="display: none;">
+                            <div class="loader"></div>
+                        </div>
+                        <p class="stat-chart-empty" id="quiz-chart-empty" style="display: none;">Chọn một bộ để xem hoạt động.</p>
+                        <canvas id="quiz-activity-chart" aria-label="Biểu đồ hoạt động trắc nghiệm"></canvas>
+                    </div>
+                </div>
             </div>
         </div>
 
@@ -351,6 +398,25 @@
                         <ul class="stat-detail-list" id="course-recent-list"></ul>
                     </div>
                 </div>
+                <div class="stat-chart-section">
+                    <div class="stat-chart-header">
+                        <span class="stat-chart-title">Hoạt động gần đây</span>
+                        <select id="course-chart-range" class="stat-chart-range">
+                            <option value="7d">7 ngày</option>
+                            <option value="30d" selected>30 ngày</option>
+                            <option value="90d">90 ngày</option>
+                            <option value="365d">365 ngày</option>
+                            <option value="all">Toàn bộ</option>
+                        </select>
+                    </div>
+                    <div class="stat-chart-body">
+                        <div class="loader-container" id="course-chart-loader" style="display: none;">
+                            <div class="loader"></div>
+                        </div>
+                        <p class="stat-chart-empty" id="course-chart-empty" style="display: none;">Chọn một khoá học để xem hoạt động.</p>
+                        <canvas id="course-activity-chart" aria-label="Biểu đồ hoạt động khoá học"></canvas>
+                    </div>
+                </div>
             </div>
         </div>
     </div>
@@ -392,6 +458,7 @@
 
 {% block scripts %}
     {{ super() }}
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js" integrity="sha384-qSxAi8uKXu95syEHCqB6f+GO6zkRgZNpmjDoE7YQDdyCjTiMQuuLHfoalGoVYLRH" crossorigin="anonymous"></script>
     <script>
         document.addEventListener('DOMContentLoaded', function() {
             const timeframeTabs = document.querySelector('.timeframe-tabs');
@@ -478,6 +545,209 @@
             const flashcardItemsEndpoint = "{{ url_for('stats.get_flashcard_items_api') }}";
             const quizItemsEndpoint = "{{ url_for('stats.get_quiz_items_api') }}";
             const courseItemsEndpoint = "{{ url_for('stats.get_course_items_api') }}";
+            const flashcardActivityEndpoint = "{{ url_for('stats.get_flashcard_activity_api') }}";
+            const quizActivityEndpoint = "{{ url_for('stats.get_quiz_activity_api') }}";
+            const courseActivityEndpoint = "{{ url_for('stats.get_course_activity_api') }}";
+
+            const activityConfig = {
+                flashcard: {
+                    endpoint: flashcardActivityEndpoint,
+                    selectId: 'flashcard-set-select',
+                    rangeId: 'flashcard-chart-range',
+                    canvasId: 'flashcard-activity-chart',
+                    emptyId: 'flashcard-chart-empty',
+                    loaderId: 'flashcard-chart-loader',
+                },
+                quiz: {
+                    endpoint: quizActivityEndpoint,
+                    selectId: 'quiz-set-select',
+                    rangeId: 'quiz-chart-range',
+                    canvasId: 'quiz-activity-chart',
+                    emptyId: 'quiz-chart-empty',
+                    loaderId: 'quiz-chart-loader',
+                },
+                course: {
+                    endpoint: courseActivityEndpoint,
+                    selectId: 'course-set-select',
+                    rangeId: 'course-chart-range',
+                    canvasId: 'course-activity-chart',
+                    emptyId: 'course-chart-empty',
+                    loaderId: 'course-chart-loader',
+                },
+            };
+
+            const activityCharts = {};
+
+            function setupActivityCharts() {
+                Object.entries(activityConfig).forEach(([type, config]) => {
+                    const selectEl = document.getElementById(config.selectId);
+                    const rangeEl = document.getElementById(config.rangeId);
+                    const canvas = document.getElementById(config.canvasId);
+                    const emptyEl = document.getElementById(config.emptyId);
+                    const loaderEl = document.getElementById(config.loaderId);
+                    const endpoint = config.endpoint;
+
+                    if (!canvas || !endpoint) {
+                        if (emptyEl) {
+                            emptyEl.textContent = 'Biểu đồ chưa khả dụng cho mục này.';
+                            emptyEl.style.display = 'flex';
+                        }
+                        return;
+                    }
+
+                    const ctx = canvas.getContext('2d');
+                    let chartInstance = null;
+
+                    function showEmpty(message) {
+                        if (loaderEl) loaderEl.style.display = 'none';
+                        if (emptyEl) {
+                            emptyEl.textContent = message;
+                            emptyEl.style.display = 'flex';
+                        }
+                        canvas.style.display = 'none';
+                    }
+
+                    function render(series) {
+                        if (!Array.isArray(series) || series.length === 0) {
+                            showEmpty('Chưa có dữ liệu hoạt động.');
+                            return;
+                        }
+
+                        const labels = series.map(point => point.date);
+                        const newCounts = series.map(point => point.new_count || 0);
+                        const reviewCounts = series.map(point => point.review_count || 0);
+                        const scores = series.map(point => point.score || 0);
+
+                        const datasets = [
+                            {
+                                label: 'Mới',
+                                data: newCounts,
+                                borderColor: '#3b82f6',
+                                backgroundColor: 'rgba(59, 130, 246, 0.15)',
+                                tension: 0.25,
+                                fill: true,
+                                yAxisID: 'y',
+                            },
+                            {
+                                label: 'Ôn',
+                                data: reviewCounts,
+                                borderColor: '#22c55e',
+                                backgroundColor: 'rgba(34, 197, 94, 0.15)',
+                                tension: 0.25,
+                                fill: true,
+                                yAxisID: 'y',
+                            },
+                            {
+                                label: 'Điểm',
+                                data: scores,
+                                borderColor: '#f59e0b',
+                                backgroundColor: 'rgba(245, 158, 11, 0.15)',
+                                tension: 0.25,
+                                fill: false,
+                                yAxisID: 'y1',
+                            },
+                        ];
+
+                        if (!chartInstance) {
+                            chartInstance = new Chart(ctx, {
+                                type: 'line',
+                                data: {
+                                    labels,
+                                    datasets,
+                                },
+                                options: {
+                                    responsive: true,
+                                    maintainAspectRatio: false,
+                                    interaction: { mode: 'index', intersect: false },
+                                    scales: {
+                                        y: {
+                                            beginAtZero: true,
+                                            title: { display: true, text: 'Lượt' },
+                                        },
+                                        y1: {
+                                            beginAtZero: true,
+                                            position: 'right',
+                                            grid: { drawOnChartArea: false },
+                                            title: { display: true, text: 'Điểm' },
+                                        },
+                                    },
+                                    plugins: {
+                                        legend: { position: 'bottom' },
+                                    },
+                                },
+                            });
+                        } else {
+                            chartInstance.data.labels = labels;
+                            chartInstance.data.datasets.forEach((dataset, index) => {
+                                dataset.data = datasets[index].data;
+                            });
+                            chartInstance.update();
+                        }
+
+                        if (loaderEl) loaderEl.style.display = 'none';
+                        if (emptyEl) emptyEl.style.display = 'none';
+                        canvas.style.display = 'block';
+                    }
+
+                    function fetchData() {
+                        const containerId = selectEl ? selectEl.value : null;
+                        if (!containerId) {
+                            showEmpty('Hãy chọn một bộ để xem hoạt động.');
+                            return;
+                        }
+
+                        if (loaderEl) loaderEl.style.display = 'flex';
+                        if (emptyEl) emptyEl.style.display = 'none';
+                        canvas.style.display = 'none';
+
+                        const params = new URLSearchParams({ container_id: containerId });
+                        if (rangeEl && rangeEl.value) {
+                            params.set('timeframe', rangeEl.value);
+                        }
+
+                        fetch(`${endpoint}?${params.toString()}`)
+                            .then(response => response.json())
+                            .then(result => {
+                                if (result.success && result.data) {
+                                    render(result.data.series || []);
+                                } else {
+                                    showEmpty('Không thể tải dữ liệu hoạt động.');
+                                }
+                            })
+                            .catch(() => {
+                                showEmpty('Không thể tải dữ liệu hoạt động.');
+                            })
+                            .finally(() => {
+                                if (loaderEl) loaderEl.style.display = 'none';
+                            });
+                    }
+
+                    if (selectEl) {
+                        selectEl.addEventListener('change', fetchData);
+                        const hasOptions = selectEl.dataset.hasOptions !== 'false';
+                        if (!hasOptions) {
+                            showEmpty('Bạn chưa có bộ nào để hiển thị.');
+                            return;
+                        }
+                        if (selectEl.value) {
+                            fetchData();
+                        } else {
+                            showEmpty('Hãy chọn một bộ để xem hoạt động.');
+                        }
+                    } else {
+                        showEmpty('Không tìm thấy lựa chọn phù hợp.');
+                    }
+
+                    if (rangeEl) {
+                        rangeEl.addEventListener('change', fetchData);
+                    }
+
+                    activityCharts[type] = {
+                        refresh: fetchData,
+                        showEmpty,
+                    };
+                });
+            }
 
             const numberFormatter = new Intl.NumberFormat('vi-VN');
 
@@ -1259,6 +1529,7 @@
             setupFlashcardMetrics();
             setupQuizMetrics();
             setupCourseMetrics();
+            setupActivityCharts();
         });
     </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add reusable helpers and flashcard, quiz, and course activity aggregation endpoints for the stats module
- enhance the statistics dashboard with Chart.js activity charts and timeframe controls for each learning container type
- extend test fixtures and add coverage for the new activity APIs

## Testing
- pytest tests/test_stats_api.py

------
https://chatgpt.com/codex/tasks/task_e_68d6a7c85b288326ae26b57dd0b47f1f