### PR TITLE
Adjust statistics layout widths

### DIFF
--- a/mindstack_app/modules/stats/templates/statistics.html
+++ b/mindstack_app/modules/stats/templates/statistics.html
@@ -15,7 +15,7 @@
             --cal-heatmap-scrolly-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
         }
 
-        .dashboard-container { max-width: 1200px; margin: 0 auto; padding: 2rem 1rem; font-family: 'Inter', sans-serif; }
+        .dashboard-container { width: min(100%, 1400px); margin: 0 auto; padding: 2rem 1rem; font-family: 'Inter', sans-serif; }
         .dashboard-header { font-size: 2.25rem; font-weight: 800; color: var(--text-primary); text-align: center; margin-bottom: 2.5rem; }
         .stats-section { background-color: var(--card-background); border-radius: 0.75rem; padding: 1.5rem; box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06); margin-bottom: 2rem; }
         .section-title { font-size: 1.5rem; font-weight: 700; color: var(--text-primary); margin-bottom: 1.5rem; display: flex; align-items: center; }
@@ -45,8 +45,8 @@
         @keyframes spin { 0% { transform: rotate(0deg); } 100% { transform: rotate(360deg); } }
 
         /* Bổ sung cột thứ 3 cho Khoá học */
-        .stats-main-grid { display: grid; grid-template-columns: 1fr; gap: 2rem; }
-        @media (min-width: 1024px) { .stats-main-grid { grid-template-columns: repeat(3, 1fr); } }
+        .stats-main-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(360px, 1fr)); gap: 2rem; }
+        @media (min-width: 1024px) { .stats-main-grid { grid-template-columns: repeat(auto-fit, minmax(360px, 1fr)); } }
         
         .stat-cards-grid { display: grid; grid-template-columns: 1fr; gap: 1rem; }
         .stat-card { display: flex; align-items: center; background-color: #f9fafb; padding: 1rem; border-radius: 0.5rem; border: 1px solid var(--border-color); }


### PR DESCRIPTION
## Summary
- expand the statistics dashboard container to support a wider 1400px layout
- update the main statistics grid to use auto-fit 360px columns so three sections stay aligned on large screens

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68d6ae418ffc8326aab7ac3b37ddf0ab