### PR TITLE
Add audioop-lts dependency for Python 3.13 and document setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# Mindstack App
+
+## Cài đặt
+1. Tạo môi trường ảo với Python 3.12 (khuyến nghị) hoặc Python 3.13.
+2. Nếu sử dụng Python 3.13, cài thêm gói tương thích `audioop-lts` để khôi phục mô-đun `audioop` mà `pydub` cần:
+   ```bash
+   pip install audioop-lts
+   ```
+   Gói này đã được khai báo trong `requirements.txt` với điều kiện `python_version >= "3.13"`, vì vậy chạy `pip install -r requirements.txt` trên Python 3.13 sẽ tự động cài đặt.
+3. Cài đặt các phụ thuộc còn lại:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+## Chạy ứng dụng
+Sử dụng lệnh sau sau khi đã cài đặt phụ thuộc:
+```bash
+python start_mindstack_app.py
+```
+Ứng dụng sẽ khởi chạy server nội bộ của Mindstack.

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,7 @@ openpyxl>=3.0 # Thư viện phụ trợ cho pandas để làm việc với file 
 bbcode>=1.0 # Dùng để chuyển đổi BBCode sang HTML trong các bài học
 gTTS>=2.2 # Google Text-to-Speech, dùng để tạo file audio cho flashcard
 pydub>=0.25 # Dùng để xử lý và ghép các file audio
+audioop-lts>=0.2; python_version >= "3.13" # Cung cấp lại mô-đun audioop bị loại bỏ từ Python 3.13 trở lên
 
 # --- Tích hợp AI ---
 google-generativeai>=0.3 # Thư viện để tương tác với Google Gemini API


### PR DESCRIPTION
## Summary
- add the audioop-lts conditional dependency so Python 3.13 environments supply the audioop module required by pydub
- document installation guidance, calling out the Python 3.13 requirement for audioop-lts and the Python 3.12 fallback option

## Testing
- ⚠️ `PYENV_VERSION=3.13.3 pyenv exec pip install -r requirements.txt` *(fails: proxy 403 while downloading packages)*
- ⚠️ `PYENV_VERSION=3.13.3 pyenv exec python start_mindstack_app.py` *(fails: ModuleNotFoundError: No module named 'flask' because dependencies are missing due to the previous installation failure)*

------
https://chatgpt.com/codex/tasks/task_e_68d6ca026bbc8326ba5feab01aef61f7