### PR TITLE
Handle ddgs package rename for image search

### DIFF
--- a/mindstack_app/modules/learning/flashcard_learning/image_service.py
+++ b/mindstack_app/modules/learning/flashcard_learning/image_service.py
@@ -13,8 +13,15 @@ from typing import Iterable, Optional, Tuple
 from urllib.parse import urlparse
 
 import requests
-from duckduckgo_search import DDGS
-from duckduckgo_search.exceptions import DuckDuckGoSearchException
+
+try:  # Ưu tiên package mới "ddgs" sau khi được đổi tên
+    from ddgs import DDGS  # type: ignore[import-not-found]
+    from ddgs.exceptions import DuckDuckGoSearchException  # type: ignore[import-not-found]
+except ModuleNotFoundError:  # Fallback cho môi trường chưa nâng cấp
+    from duckduckgo_search import DDGS  # type: ignore[import-not-found]
+    from duckduckgo_search.exceptions import (  # type: ignore[import-not-found]
+        DuckDuckGoSearchException,
+    )
 from sqlalchemy.orm.attributes import flag_modified
 
 from ....config import Config

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,5 +36,5 @@ itsdangerous>=2.0 # Dùng để ký dữ liệu an toàn trong Flask
 click>=8.0 # Dùng để tạo các lệnh command-line cho Flask
 
 # --- Tự động tìm kiếm và tải hình ảnh ---
-duckduckgo-search>=4.0.0
+ddgs>=5.3.0
 requests>=2.31


### PR DESCRIPTION
## Summary
- update the flashcard image service to prefer the renamed `ddgs` package while keeping a fallback for older environments
- bump requirements to install `ddgs` instead of the deprecated `duckduckgo-search`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d6da9269f88326b4a8d8c69aa1ca49