### PR TITLE
Handle DuckDuckGo exception import compatibility

### DIFF
--- a/mindstack_app/modules/learning/flashcard_learning/image_service.py
+++ b/mindstack_app/modules/learning/flashcard_learning/image_service.py
@@ -16,7 +16,12 @@ import requests
 
 try:  # Ưu tiên package mới "ddgs" sau khi được đổi tên
     from ddgs import DDGS  # type: ignore[import-not-found]
-    from ddgs.exceptions import DuckDuckGoSearchException  # type: ignore[import-not-found]
+    from ddgs import exceptions as _ddgs_exceptions  # type: ignore[import-not-found]
+    DuckDuckGoSearchException = getattr(  # type: ignore[assignment]
+        _ddgs_exceptions,
+        "DuckDuckGoSearchException",
+        getattr(_ddgs_exceptions, "DDGSearchException", Exception),
+    )
 except ModuleNotFoundError:  # Fallback cho môi trường chưa nâng cấp
     from duckduckgo_search import DDGS  # type: ignore[import-not-found]
     from duckduckgo_search.exceptions import (  # type: ignore[import-not-found]


### PR DESCRIPTION
## Summary
- fall back to the available DuckDuckGo exception when using the renamed `ddgs` package
- keep compatibility with the older `duckduckgo_search` package fallback

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6dbe86f9c8326892b8bdbfff08c31