### PR TITLE
Restrict flashcard image generation to editors and add inline picker

### DIFF
--- a/mindstack_app/modules/content_management/flashcards/templates/_add_edit_flashcard_item_bare.html
+++ b/mindstack_app/modules/content_management/flashcards/templates/_add_edit_flashcard_item_bare.html
@@ -46,7 +46,13 @@
             </h2>
             <p class="text-center text-gray-600 mb-6">Điền thông tin dưới đây để tạo một thẻ ghi nhớ mới.</p>
 
-            <form id="flashcardItemForm" action="" method="post" class="space-y-6">
+            <form id="flashcardItemForm"
+                  action=""
+                  method="post"
+                  class="space-y-6"
+                  data-image-search-url="{{ image_search_url }}"
+                  data-front-source-id="{{ form.front.id }}"
+                  data-back-source-id="{{ form.back.id }}">
                 {{ form.csrf_token }}
                 
                 <div>
@@ -91,13 +97,67 @@
                             {{ form.back_audio_url.label(class="block text-sm font-medium text-gray-700") }}
                             {{ form.back_audio_url(class="mt-1 block w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500", placeholder="URL file âm thanh mặt sau") }}
                         </div>
-                        <div>
+                        <div data-image-side="front"
+                             data-initial-url="{{ front_image_url or '' }}">
+                            {{ form.front_img(type='hidden', id=form.front_img.id, data-role='image-path') }}
                             {{ form.front_img.label(class="block text-sm font-medium text-gray-700") }}
-                            {{ form.front_img(class="mt-1 block w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500", placeholder="URL hình ảnh mặt trước") }}
+                            <div class="flex flex-col sm:flex-row gap-4 mt-2">
+                                <div class="relative w-full sm:w-40 h-40 border border-dashed border-gray-300 rounded-lg flex items-center justify-center bg-gray-50 overflow-hidden" data-role="image-preview-wrapper">
+                                    <img src="{{ front_image_url }}" alt="Hình ảnh mặt trước" class="max-h-full max-w-full {{ '' if front_image_url else 'hidden' }}" data-role="image-preview">
+                                    <span class="text-gray-400 text-xs text-center px-2 {{ 'hidden' if front_image_url else '' }}" data-role="image-placeholder">Chưa có hình ảnh</span>
+                                    <button type="button" class="absolute top-1 right-1 text-gray-500 hover:text-red-500 transition {{ '' if front_image_url else 'hidden' }}" data-role="remove-image" aria-label="Xoá hình ảnh">
+                                        <i class="fas fa-times"></i>
+                                    </button>
+                                </div>
+                                <div class="flex-1 space-y-2">
+                                    <div class="flex flex-col sm:flex-row gap-2">
+                                        <input type="text"
+                                               class="flex-1 px-4 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                                               placeholder="Từ khóa tìm ảnh..."
+                                               value="{{ form.front.data or '' }}"
+                                               data-role="image-query">
+                                        <button type="button"
+                                                class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition duration-300 flex items-center justify-center gap-2"
+                                                data-role="search-image">
+                                            <i class="fas fa-image"></i>
+                                            <span>Tìm ảnh</span>
+                                        </button>
+                                    </div>
+                                    <p class="text-xs text-gray-500">Mặc định sử dụng nội dung mặt trước, bạn có thể chỉnh sửa trước khi tìm.</p>
+                                    <p class="text-sm text-red-500 hidden" data-role="image-error"></p>
+                                </div>
+                            </div>
                         </div>
-                        <div>
+                        <div data-image-side="back"
+                             data-initial-url="{{ back_image_url or '' }}">
+                            {{ form.back_img(type='hidden', id=form.back_img.id, data-role='image-path') }}
                             {{ form.back_img.label(class="block text-sm font-medium text-gray-700") }}
-                            {{ form.back_img(class="mt-1 block w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500", placeholder="URL hình ảnh mặt sau") }}
+                            <div class="flex flex-col sm:flex-row gap-4 mt-2">
+                                <div class="relative w-full sm:w-40 h-40 border border-dashed border-gray-300 rounded-lg flex items-center justify-center bg-gray-50 overflow-hidden" data-role="image-preview-wrapper">
+                                    <img src="{{ back_image_url }}" alt="Hình ảnh mặt sau" class="max-h-full max-w-full {{ '' if back_image_url else 'hidden' }}" data-role="image-preview">
+                                    <span class="text-gray-400 text-xs text-center px-2 {{ 'hidden' if back_image_url else '' }}" data-role="image-placeholder">Chưa có hình ảnh</span>
+                                    <button type="button" class="absolute top-1 right-1 text-gray-500 hover:text-red-500 transition {{ '' if back_image_url else 'hidden' }}" data-role="remove-image" aria-label="Xoá hình ảnh">
+                                        <i class="fas fa-times"></i>
+                                    </button>
+                                </div>
+                                <div class="flex-1 space-y-2">
+                                    <div class="flex flex-col sm:flex-row gap-2">
+                                        <input type="text"
+                                               class="flex-1 px-4 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                                               placeholder="Từ khóa tìm ảnh..."
+                                               value="{{ form.back.data or '' }}"
+                                               data-role="image-query">
+                                        <button type="button"
+                                                class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition duration-300 flex items-center justify-center gap-2"
+                                                data-role="search-image">
+                                            <i class="fas fa-image"></i>
+                                            <span>Tìm ảnh</span>
+                                        </button>
+                                    </div>
+                                    <p class="text-xs text-gray-500">Mặc định sử dụng nội dung mặt sau, bạn có thể chỉnh sửa trước khi tìm.</p>
+                                    <p class="text-sm text-red-500 hidden" data-role="image-error"></p>
+                                </div>
+                            </div>
                         </div>
                         <div>
                             {{ form.ai_prompt.label(class="block text-sm font-medium text-gray-700") }}
@@ -128,6 +188,8 @@
         </div>
     </div>
 </div>
+
+{% include 'flashcards/_flashcard_image_control_scripts.html' %}
 
 <script>
     document.addEventListener('DOMContentLoaded', function() {
@@ -176,6 +238,7 @@
         }
         
         if (form) {
+            initializeFlashcardImageControls({ form: form });
             {# Đặt action của form dựa trên URL hiện tại (để xử lý cả add và edit) #}
             const currentUrl = new URL(window.location.href);
             currentUrl.searchParams.delete('is_modal'); 

--- a/mindstack_app/modules/content_management/flashcards/templates/_flashcard_image_control_scripts.html
+++ b/mindstack_app/modules/content_management/flashcards/templates/_flashcard_image_control_scripts.html
@@ -1,0 +1,157 @@
+<script>
+(function() {
+    if (window.initializeFlashcardImageControls) {
+        return;
+    }
+
+    window.initializeFlashcardImageControls = function initializeFlashcardImageControls(options) {
+        const opts = options || {};
+        const formElement = opts.form || (opts.formSelector ? document.querySelector(opts.formSelector) : null);
+        if (!formElement) {
+            return;
+        }
+
+        const searchUrl = opts.searchUrl || formElement.dataset.imageSearchUrl;
+        if (!searchUrl) {
+            return;
+        }
+
+        const fields = Array.from(formElement.querySelectorAll('[data-image-side]'));
+        if (!fields.length) {
+            return;
+        }
+
+        const csrfInput = formElement.querySelector('input[name="csrf_token"]');
+        const csrfToken = csrfInput ? csrfInput.value : '';
+
+        const getDefaultQuery = (field) => {
+            const side = field.dataset.imageSide || 'front';
+            const sourceId = side === 'back' ? formElement.dataset.backSourceId : formElement.dataset.frontSourceId;
+            if (!sourceId) {
+                return '';
+            }
+            const sourceField = document.getElementById(sourceId);
+            if (!sourceField) {
+                return '';
+            }
+            return (sourceField.value || '').trim();
+        };
+
+        fields.forEach(field => {
+            const side = (field.dataset.imageSide || 'front').toLowerCase();
+            const hiddenInput = field.querySelector('[data-role="image-path"]');
+            const previewImg = field.querySelector('[data-role="image-preview"]');
+            const placeholder = field.querySelector('[data-role="image-placeholder"]');
+            const removeBtn = field.querySelector('[data-role="remove-image"]');
+            const queryInput = field.querySelector('[data-role="image-query"]');
+            const searchBtn = field.querySelector('[data-role="search-image"]');
+            const errorLabel = field.querySelector('[data-role="image-error"]');
+            const initialUrl = field.dataset.initialUrl || '';
+
+            if (!hiddenInput || !searchBtn) {
+                return;
+            }
+
+            const updatePreview = (url) => {
+                const hasUrl = Boolean(url);
+                if (previewImg) {
+                    if (hasUrl) {
+                        previewImg.src = url;
+                        previewImg.classList.remove('hidden');
+                    } else {
+                        previewImg.removeAttribute('src');
+                        previewImg.classList.add('hidden');
+                    }
+                }
+                if (placeholder) {
+                    placeholder.classList.toggle('hidden', hasUrl);
+                }
+                if (removeBtn) {
+                    removeBtn.classList.toggle('hidden', !hasUrl);
+                }
+            };
+
+            updatePreview(initialUrl);
+
+            if (removeBtn) {
+                removeBtn.addEventListener('click', (event) => {
+                    event.preventDefault();
+                    hiddenInput.value = '';
+                    updatePreview('');
+                    if (errorLabel) {
+                        errorLabel.textContent = '';
+                        errorLabel.classList.add('hidden');
+                    }
+                });
+            }
+
+            searchBtn.addEventListener('click', async () => {
+                if (errorLabel) {
+                    errorLabel.textContent = '';
+                    errorLabel.classList.add('hidden');
+                }
+
+                let query = queryInput ? queryInput.value.trim() : '';
+                if (!query) {
+                    query = getDefaultQuery(field);
+                    if (queryInput && query) {
+                        queryInput.value = query;
+                    }
+                }
+
+                if (!query) {
+                    if (errorLabel) {
+                        errorLabel.textContent = 'Vui lòng nhập nội dung để tìm ảnh.';
+                        errorLabel.classList.remove('hidden');
+                    }
+                    if (queryInput) {
+                        queryInput.focus();
+                    }
+                    return;
+                }
+
+                const originalHtml = searchBtn.dataset.originalHtml || searchBtn.innerHTML;
+                if (!searchBtn.dataset.originalHtml) {
+                    searchBtn.dataset.originalHtml = originalHtml;
+                }
+                searchBtn.innerHTML = '<i class="fas fa-spinner fa-spin"></i>';
+                searchBtn.disabled = true;
+
+                try {
+                    const response = await fetch(searchUrl, {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                            'X-Requested-With': 'XMLHttpRequest',
+                            ...(csrfToken ? { 'X-CSRFToken': csrfToken } : {})
+                        },
+                        body: JSON.stringify({ side, query })
+                    });
+
+                    const result = await response.json();
+
+                    if (response.ok && result && result.success && result.image_url) {
+                        hiddenInput.value = result.relative_path || '';
+                        updatePreview(result.image_url);
+                    } else {
+                        const message = (result && result.message) || 'Không tìm thấy ảnh phù hợp.';
+                        if (errorLabel) {
+                            errorLabel.textContent = message;
+                            errorLabel.classList.remove('hidden');
+                        }
+                    }
+                } catch (error) {
+                    console.error('Lỗi tìm ảnh minh họa:', error);
+                    if (errorLabel) {
+                        errorLabel.textContent = 'Không thể kết nối đến máy chủ tìm kiếm ảnh.';
+                        errorLabel.classList.remove('hidden');
+                    }
+                } finally {
+                    searchBtn.innerHTML = searchBtn.dataset.originalHtml || originalHtml;
+                    searchBtn.disabled = false;
+                }
+            });
+        });
+    };
+})();
+</script>

--- a/mindstack_app/modules/content_management/flashcards/templates/add_edit_flashcard_item.html
+++ b/mindstack_app/modules/content_management/flashcards/templates/add_edit_flashcard_item.html
@@ -18,7 +18,13 @@
             </h2>
             <p class="text-center text-gray-600 mb-6">Điền thông tin dưới đây để {{ "tạo thẻ mới" if title == "Thêm Thẻ Flashcard mới" else "sửa thẻ" }}.</p>
 
-            <form action="" method="post" class="space-y-6">
+            <form id="flashcardItemForm"
+                  action=""
+                  method="post"
+                  class="space-y-6"
+                  data-image-search-url="{{ image_search_url }}"
+                  data-front-source-id="{{ form.front.id }}"
+                  data-back-source-id="{{ form.back.id }}">
                 {{ form.csrf_token }}
                 
                 <div>
@@ -80,18 +86,72 @@
                                 </div>
                             {% endif %}
                         </div>
-                        <div>
+                        <div data-image-side="front"
+                             data-initial-url="{{ front_image_url or '' }}">
+                            {{ form.front_img(type='hidden', id=form.front_img.id, data-role='image-path') }}
                             {{ form.front_img.label(class="block text-sm font-medium text-gray-700") }}
-                            {{ form.front_img(class="mt-1 block w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500", placeholder="URL hình ảnh mặt trước") }}
+                            <div class="flex flex-col sm:flex-row gap-4 mt-2">
+                                <div class="relative w-full sm:w-40 h-40 border border-dashed border-gray-300 rounded-lg flex items-center justify-center bg-gray-50 overflow-hidden" data-role="image-preview-wrapper">
+                                    <img src="{{ front_image_url }}" alt="Hình ảnh mặt trước" class="max-h-full max-w-full {{ '' if front_image_url else 'hidden' }}" data-role="image-preview">
+                                    <span class="text-gray-400 text-xs text-center px-2 {{ 'hidden' if front_image_url else '' }}" data-role="image-placeholder">Chưa có hình ảnh</span>
+                                    <button type="button" class="absolute top-1 right-1 text-gray-500 hover:text-red-500 transition {{ '' if front_image_url else 'hidden' }}" data-role="remove-image" aria-label="Xoá hình ảnh">
+                                        <i class="fas fa-times"></i>
+                                    </button>
+                                </div>
+                                <div class="flex-1 space-y-2">
+                                    <div class="flex flex-col sm:flex-row gap-2">
+                                        <input type="text"
+                                               class="flex-1 px-4 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                                               placeholder="Từ khóa tìm ảnh..."
+                                               value="{{ form.front.data or '' }}"
+                                               data-role="image-query">
+                                        <button type="button"
+                                                class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition duration-300 flex items-center justify-center gap-2"
+                                                data-role="search-image">
+                                            <i class="fas fa-image"></i>
+                                            <span>Tìm ảnh</span>
+                                        </button>
+                                    </div>
+                                    <p class="text-xs text-gray-500">Mặc định sử dụng nội dung mặt trước, bạn có thể chỉnh sửa trước khi tìm.</p>
+                                    <p class="text-sm text-red-500 hidden" data-role="image-error"></p>
+                                </div>
+                            </div>
                             {% if form.front_img.errors %}
                                 <div class="text-red-500 text-xs mt-1">
                                     {% for error in form.front_img.errors %}<p>{{ error }}</p>{% endfor %}
                                 </div>
                             {% endif %}
                         </div>
-                        <div>
+                        <div data-image-side="back"
+                             data-initial-url="{{ back_image_url or '' }}">
+                            {{ form.back_img(type='hidden', id=form.back_img.id, data-role='image-path') }}
                             {{ form.back_img.label(class="block text-sm font-medium text-gray-700") }}
-                            {{ form.back_img(class="mt-1 block w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500", placeholder="URL hình ảnh mặt sau") }}
+                            <div class="flex flex-col sm:flex-row gap-4 mt-2">
+                                <div class="relative w-full sm:w-40 h-40 border border-dashed border-gray-300 rounded-lg flex items-center justify-center bg-gray-50 overflow-hidden" data-role="image-preview-wrapper">
+                                    <img src="{{ back_image_url }}" alt="Hình ảnh mặt sau" class="max-h-full max-w-full {{ '' if back_image_url else 'hidden' }}" data-role="image-preview">
+                                    <span class="text-gray-400 text-xs text-center px-2 {{ 'hidden' if back_image_url else '' }}" data-role="image-placeholder">Chưa có hình ảnh</span>
+                                    <button type="button" class="absolute top-1 right-1 text-gray-500 hover:text-red-500 transition {{ '' if back_image_url else 'hidden' }}" data-role="remove-image" aria-label="Xoá hình ảnh">
+                                        <i class="fas fa-times"></i>
+                                    </button>
+                                </div>
+                                <div class="flex-1 space-y-2">
+                                    <div class="flex flex-col sm:flex-row gap-2">
+                                        <input type="text"
+                                               class="flex-1 px-4 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                                               placeholder="Từ khóa tìm ảnh..."
+                                               value="{{ form.back.data or '' }}"
+                                               data-role="image-query">
+                                        <button type="button"
+                                                class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition duration-300 flex items-center justify-center gap-2"
+                                                data-role="search-image">
+                                            <i class="fas fa-image"></i>
+                                            <span>Tìm ảnh</span>
+                                        </button>
+                                    </div>
+                                    <p class="text-xs text-gray-500">Mặc định sử dụng nội dung mặt sau, bạn có thể chỉnh sửa trước khi tìm.</p>
+                                    <p class="text-sm text-red-500 hidden" data-role="image-error"></p>
+                                </div>
+                            </div>
                             {% if form.back_img.errors %}
                                 <div class="text-red-500 text-xs mt-1">
                                     {% for error in form.back_img.errors %}<p>{{ error }}</p>{% endfor %}
@@ -130,4 +190,14 @@
         </div>
     </div>
 </div>
+{% endblock %}
+
+{% block scripts %}
+{{ super() }}
+{% include 'flashcards/_flashcard_image_control_scripts.html' %}
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+        initializeFlashcardImageControls({ formSelector: '#flashcardItemForm' });
+    });
+</script>
 {% endblock %}

--- a/mindstack_app/modules/learning/flashcard_learning/templates/flashcard_session.html
+++ b/mindstack_app/modules/learning/flashcard_learning/templates/flashcard_session.html
@@ -859,7 +859,6 @@
     const submitAnswerUrl = "{{ url_for('learning.flashcard_learning.submit_flashcard_answer') }}";
     const endSessionUrl = "{{ url_for('learning.flashcard_learning.end_session_flashcard') }}";
     const regenerateAudioUrl = "{{ url_for('learning.flashcard_learning.regenerate_audio_from_content') }}";
-    const regenerateImageUrl = "{{ url_for('learning.flashcard_learning.generate_image_from_content') }}";
     const userButtonCount = {{ user_button_count }};
     const isAutoplaySession = {{ 'true' if is_autoplay_session else 'false' }};
     const autoplayMode = "{{ autoplay_mode }}";
@@ -1245,17 +1244,11 @@
         const hasBackAudio = currentFlashcardBatch[currentFlashcardIndex].content.back_audio_url || currentFlashcardBatch[currentFlashcardIndex].content.back_audio_content;
         const frontTextRaw = currentFlashcardBatch[currentFlashcardIndex].content.front || '';
         const backTextRaw = currentFlashcardBatch[currentFlashcardIndex].content.back || '';
-        const canGenerateFrontImage = extractPlainText(frontTextRaw).length > 0;
-        const canGenerateBackImage = extractPlainText(backTextRaw).length > 0;
-
         const menuButtonHtml = isMobile ? `<button class="icon-btn open-stats-modal-btn"><i class="fas fa-bars"></i></button>` : '';
         const aiButtonHtml = `<button class="icon-btn open-ai-modal-btn" data-item-id="${itemId}"><i class="fas fa-robot"></i></button>`;
         const noteButtonHtml = `<button class="icon-btn open-note-panel-btn" data-item-id="${itemId}"><i class="fas fa-sticky-note"></i></button>`;
         const feedbackButtonHtml = `<button class="icon-btn open-feedback-modal-btn" data-item-id="${itemId}"><i class="fas fa-flag"></i></button>`;
         const editButtonHtml = `<button class="icon-btn edit-card-btn" onclick="window.parent.openModal('{{ url_for('content_management.content_management_flashcards.edit_flashcard_item', set_id=0, item_id=0) }}'.replace('/0', '/${setId}').replace('/0', '/${itemId}'))"><i class="fas fa-pencil-alt"></i></button>`;
-
-        const imageButtonHtmlFront = `<button class="icon-btn fetch-image-btn ${canGenerateFrontImage ? '' : 'is-disabled'}" data-side="front" data-item-id="${itemId}" ${canGenerateFrontImage ? '' : 'disabled'}><i class="fas fa-image"></i></button>`;
-        const imageButtonHtmlBack = `<button class="icon-btn fetch-image-btn ${canGenerateBackImage ? '' : 'is-disabled'}" data-side="back" data-item-id="${itemId}" ${canGenerateBackImage ? '' : 'disabled'}><i class="fas fa-image"></i></button>`;
 
         const audioButtonHtmlFront = `<button class="icon-btn play-audio-btn ${hasFrontAudio ? '' : 'is-disabled'}" data-audio-target="#front-audio" data-side="front" data-item-id="${itemId}" data-content-to-read="${currentFlashcardBatch[currentFlashcardIndex].content.front_audio_content || ''}" ${hasFrontAudio ? '' : 'disabled'}><i class="fas fa-volume-up"></i></button>`;
         const audioButtonHtmlBack = `<button class="icon-btn play-audio-btn ${hasBackAudio ? '' : 'is-disabled'}" data-audio-target="#back-audio" data-side="back" data-item-id="${itemId}" data-content-to-read="${currentFlashcardBatch[currentFlashcardIndex].content.back_audio_content || ''}" ${hasBackAudio ? '' : 'disabled'}><i class="fas fa-volume-up"></i></button>`;
@@ -1270,8 +1263,8 @@
         const rightToolbarContent = `${feedbackButtonHtml}${editButtonHtml}`;
 
         return {
-            front: `<div class="card-toolbar"><div class="toolbar-left">${leftToolbarContent}</div><span class="label">MẶT TRƯỚC</span><div class="toolbar-right">${rightToolbarContent}${imageButtonHtmlFront}${audioButtonHtmlFront}</div></div>`,
-            back: `<div class="card-toolbar"><div class="toolbar-left">${leftToolbarContent}</div><span class="label">MẶT SAU</span><div class="toolbar-right">${rightToolbarContent}${imageButtonHtmlBack}${audioButtonHtmlBack}</div></div>`,
+            front: `<div class="card-toolbar"><div class="toolbar-left">${leftToolbarContent}</div><span class="label">MẶT TRƯỚC</span><div class="toolbar-right">${rightToolbarContent}${audioButtonHtmlFront}</div></div>`,
+            back: `<div class="card-toolbar"><div class="toolbar-left">${leftToolbarContent}</div><span class="label">MẶT SAU</span><div class="toolbar-right">${rightToolbarContent}${audioButtonHtmlBack}</div></div>`,
             flipButton: flipButtonHtml
         };
     }
@@ -1405,128 +1398,12 @@
       
       document.querySelectorAll('.close-media-btn').forEach(bindCloseMediaButton);
 
-      document.querySelectorAll('.fetch-image-btn').forEach(btn => {
-        btn.addEventListener('click', ev => {
-          ev.preventDefault();
-          ev.stopPropagation();
-          generateIllustrationForCard(btn);
-        });
-      });
-
       setTimeout(adjustCardLayout, 0);
 
       if (isAutoplaySession) {
         startAutoplaySequence();
       } else {
         autoPlayFrontSide();
-      }
-    }
-
-    function updateCardImageDisplay(side, imageUrl) {
-      if (!imageUrl) return;
-      const faceSelector = side === 'back' ? '.face.back' : '.face.front';
-      const face = document.querySelector(`#flashcard-card ${faceSelector}`);
-      if (!face) return;
-      const container = face.querySelector('._card-container');
-      if (!container) return;
-
-      let mediaContainer = container.querySelector('.media-container');
-      if (!mediaContainer) {
-        mediaContainer = document.createElement('div');
-        mediaContainer.className = 'media-container';
-        const img = document.createElement('img');
-        img.alt = side === 'back' ? 'Mặt sau' : 'Mặt trước';
-        img.onerror = function() {
-          this.onerror = null;
-          this.src = 'https://placehold.co/200x120?text=Loi+anh';
-        };
-        mediaContainer.appendChild(img);
-
-        const closeBtn = document.createElement('button');
-        closeBtn.className = 'close-media-btn';
-        closeBtn.innerHTML = '&times;';
-        mediaContainer.appendChild(closeBtn);
-        bindCloseMediaButton(closeBtn);
-
-        container.appendChild(mediaContainer);
-      }
-
-      const imgEl = mediaContainer.querySelector('img');
-      if (imgEl) {
-        const timestampedUrl = imageUrl.includes('?') ? `${imageUrl}&t=${Date.now()}` : `${imageUrl}?t=${Date.now()}`;
-        imgEl.src = timestampedUrl;
-        imgEl.alt = side === 'back' ? 'Mặt sau' : 'Mặt trước';
-        imgEl.onerror = function() {
-          this.onerror = null;
-          this.src = 'https://placehold.co/200x120?text=Loi+anh';
-        };
-      }
-
-      mediaContainer.classList.remove('hidden');
-      setTimeout(adjustCardLayout, 0);
-    }
-
-    async function generateIllustrationForCard(button) {
-      if (!button || button.classList.contains('is-disabled')) {
-        return;
-      }
-
-      const itemId = Number.parseInt(button.dataset.itemId || '', 10);
-      const side = (button.dataset.side || 'front').toLowerCase();
-      if (!itemId || !['front', 'back'].includes(side)) {
-        showCustomAlert('Không xác định được thẻ để tạo ảnh.');
-        return;
-      }
-
-      const cardData = Array.isArray(currentFlashcardBatch)
-        ? currentFlashcardBatch.find(item => Number(item.item_id) === itemId)
-        : null;
-      if (!cardData) {
-        showCustomAlert('Không thể tìm thấy dữ liệu thẻ hiện tại.');
-        return;
-      }
-
-      const sourceText = side === 'back' ? cardData.content.back : cardData.content.front;
-      const normalizedText = extractPlainText(sourceText);
-      if (!normalizedText) {
-        showCustomAlert('Nội dung mặt thẻ đang trống, không thể tìm ảnh.');
-        return;
-      }
-
-      const originalHtml = button.dataset.originalHtml || button.innerHTML;
-      if (!button.dataset.originalHtml) {
-        button.dataset.originalHtml = originalHtml;
-      }
-
-      button.innerHTML = '<i class="fas fa-spinner fa-spin"></i>';
-      button.classList.add('is-disabled');
-
-      try {
-        const response = await fetch(regenerateImageUrl, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ item_id: itemId, side })
-        });
-        const result = await response.json();
-        if (result.success && result.image_url) {
-          updateCardImageDisplay(side, result.image_url);
-          if (side === 'front') {
-            cardData.content.front_img = result.image_url;
-          } else {
-            cardData.content.back_img = result.image_url;
-          }
-          if (result.message) {
-            showCustomAlert(result.message);
-          }
-        } else {
-          showCustomAlert(result.message || 'Không thể tìm ảnh minh họa.');
-        }
-      } catch (error) {
-        console.error('Lỗi khi tạo ảnh minh họa:', error);
-        showCustomAlert('Không thể kết nối đến máy chủ để tìm ảnh.');
-      } finally {
-        button.classList.remove('is-disabled');
-        button.innerHTML = button.dataset.originalHtml || '<i class="fas fa-image"></i>';
       }
     }
 


### PR DESCRIPTION
## Summary
- gate the learning session image generator on editor permissions and remove the study toolbar shortcut
- add a flashcard-item image search/remove UI with live previews in both the page and modal forms
- expose a content-management search endpoint and shared client script to pull cached images into the form fields

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6dded5ea88326bfa577cf8629b0da