### PR TITLE
Fix flashcard image field attribute rendering

### DIFF
--- a/mindstack_app/modules/content_management/flashcards/templates/_add_edit_flashcard_item_bare.html
+++ b/mindstack_app/modules/content_management/flashcards/templates/_add_edit_flashcard_item_bare.html
@@ -99,7 +99,7 @@
                         </div>
                         <div data-image-side="front"
                              data-initial-url="{{ front_image_url or '' }}">
-                            {{ form.front_img(type='hidden', id=form.front_img.id, data-role='image-path') }}
+                            {{ form.front_img(type='hidden', id=form.front_img.id, data_role='image-path') }}
                             {{ form.front_img.label(class="block text-sm font-medium text-gray-700") }}
                             <div class="flex flex-col sm:flex-row gap-4 mt-2">
                                 <div class="relative w-full sm:w-40 h-40 border border-dashed border-gray-300 rounded-lg flex items-center justify-center bg-gray-50 overflow-hidden" data-role="image-preview-wrapper">
@@ -130,7 +130,7 @@
                         </div>
                         <div data-image-side="back"
                              data-initial-url="{{ back_image_url or '' }}">
-                            {{ form.back_img(type='hidden', id=form.back_img.id, data-role='image-path') }}
+                            {{ form.back_img(type='hidden', id=form.back_img.id, data_role='image-path') }}
                             {{ form.back_img.label(class="block text-sm font-medium text-gray-700") }}
                             <div class="flex flex-col sm:flex-row gap-4 mt-2">
                                 <div class="relative w-full sm:w-40 h-40 border border-dashed border-gray-300 rounded-lg flex items-center justify-center bg-gray-50 overflow-hidden" data-role="image-preview-wrapper">

--- a/mindstack_app/modules/content_management/flashcards/templates/add_edit_flashcard_item.html
+++ b/mindstack_app/modules/content_management/flashcards/templates/add_edit_flashcard_item.html
@@ -88,7 +88,7 @@
                         </div>
                         <div data-image-side="front"
                              data-initial-url="{{ front_image_url or '' }}">
-                            {{ form.front_img(type='hidden', id=form.front_img.id, data-role='image-path') }}
+                            {{ form.front_img(type='hidden', id=form.front_img.id, data_role='image-path') }}
                             {{ form.front_img.label(class="block text-sm font-medium text-gray-700") }}
                             <div class="flex flex-col sm:flex-row gap-4 mt-2">
                                 <div class="relative w-full sm:w-40 h-40 border border-dashed border-gray-300 rounded-lg flex items-center justify-center bg-gray-50 overflow-hidden" data-role="image-preview-wrapper">
@@ -124,7 +124,7 @@
                         </div>
                         <div data-image-side="back"
                              data-initial-url="{{ back_image_url or '' }}">
-                            {{ form.back_img(type='hidden', id=form.back_img.id, data-role='image-path') }}
+                            {{ form.back_img(type='hidden', id=form.back_img.id, data_role='image-path') }}
                             {{ form.back_img.label(class="block text-sm font-medium text-gray-700") }}
                             <div class="flex flex-col sm:flex-row gap-4 mt-2">
                                 <div class="relative w-full sm:w-40 h-40 border border-dashed border-gray-300 rounded-lg flex items-center justify-center bg-gray-50 overflow-hidden" data-role="image-preview-wrapper">


### PR DESCRIPTION
## Summary
- replace invalid data-role keyword arguments in flashcard item templates with WTForms-compatible data_role usage so Jinja can render the fields

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6e3ab3e40832681e9b52bedebac25