### PR TITLE
Fix flashcard image include path in content management templates

### DIFF
--- a/mindstack_app/modules/content_management/flashcards/templates/_add_edit_flashcard_item_bare.html
+++ b/mindstack_app/modules/content_management/flashcards/templates/_add_edit_flashcard_item_bare.html
@@ -189,7 +189,7 @@
     </div>
 </div>
 
-{% include 'flashcards/_flashcard_image_control_scripts.html' %}
+{% include '_flashcard_image_control_scripts.html' %}
 
 <script>
     document.addEventListener('DOMContentLoaded', function() {

--- a/mindstack_app/modules/content_management/flashcards/templates/add_edit_flashcard_item.html
+++ b/mindstack_app/modules/content_management/flashcards/templates/add_edit_flashcard_item.html
@@ -194,7 +194,7 @@
 
 {% block scripts %}
 {{ super() }}
-{% include 'flashcards/_flashcard_image_control_scripts.html' %}
+{% include '_flashcard_image_control_scripts.html' %}
 <script>
     document.addEventListener('DOMContentLoaded', function() {
         initializeFlashcardImageControls({ formSelector: '#flashcardItemForm' });


### PR DESCRIPTION
## Summary
- update the flashcard item templates to include the image control partial from the correct location
- prevent Jinja from looking for a non-existent flashcards/ subdirectory when rendering the form

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6e55ba7b48326bd2ed86e92f77999