### PR TITLE
Enable manual image URL entry for flashcards

### DIFF
--- a/mindstack_app/modules/content_management/flashcards/templates/_add_edit_flashcard_item_bare.html
+++ b/mindstack_app/modules/content_management/flashcards/templates/_add_edit_flashcard_item_bare.html
@@ -99,9 +99,9 @@
                         </div>
                         <div data-image-side="front"
                              data-initial-url="{{ front_image_url or '' }}">
-                            {{ form.front_img(type='hidden', id=form.front_img.id, data_role='image-path') }}
                             {{ form.front_img.label(class="block text-sm font-medium text-gray-700") }}
-                            <div class="flex flex-col sm:flex-row gap-4 mt-2">
+                            {{ form.front_img(class="mt-1 block w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500", id=form.front_img.id, data_role='image-path', placeholder="URL hình ảnh mặt trước") }}
+                            <div class="flex flex-col sm:flex-row gap-4 mt-3">
                                 <div class="relative w-full sm:w-40 h-40 border border-dashed border-gray-300 rounded-lg flex items-center justify-center bg-gray-50 overflow-hidden" data-role="image-preview-wrapper">
                                     <img src="{{ front_image_url }}" alt="Hình ảnh mặt trước" class="max-h-full max-w-full {{ '' if front_image_url else 'hidden' }}" data-role="image-preview">
                                     <span class="text-gray-400 text-xs text-center px-2 {{ 'hidden' if front_image_url else '' }}" data-role="image-placeholder">Chưa có hình ảnh</span>
@@ -130,9 +130,9 @@
                         </div>
                         <div data-image-side="back"
                              data-initial-url="{{ back_image_url or '' }}">
-                            {{ form.back_img(type='hidden', id=form.back_img.id, data_role='image-path') }}
                             {{ form.back_img.label(class="block text-sm font-medium text-gray-700") }}
-                            <div class="flex flex-col sm:flex-row gap-4 mt-2">
+                            {{ form.back_img(class="mt-1 block w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500", id=form.back_img.id, data_role='image-path', placeholder="URL hình ảnh mặt sau") }}
+                            <div class="flex flex-col sm:flex-row gap-4 mt-3">
                                 <div class="relative w-full sm:w-40 h-40 border border-dashed border-gray-300 rounded-lg flex items-center justify-center bg-gray-50 overflow-hidden" data-role="image-preview-wrapper">
                                     <img src="{{ back_image_url }}" alt="Hình ảnh mặt sau" class="max-h-full max-w-full {{ '' if back_image_url else 'hidden' }}" data-role="image-preview">
                                     <span class="text-gray-400 text-xs text-center px-2 {{ 'hidden' if back_image_url else '' }}" data-role="image-placeholder">Chưa có hình ảnh</span>

--- a/mindstack_app/modules/content_management/flashcards/templates/_flashcard_image_control_scripts.html
+++ b/mindstack_app/modules/content_management/flashcards/templates/_flashcard_image_control_scripts.html
@@ -39,7 +39,7 @@
 
         fields.forEach(field => {
             const side = (field.dataset.imageSide || 'front').toLowerCase();
-            const hiddenInput = field.querySelector('[data-role="image-path"]');
+            const urlInput = field.querySelector('[data-role="image-path"]');
             const previewImg = field.querySelector('[data-role="image-preview"]');
             const placeholder = field.querySelector('[data-role="image-placeholder"]');
             const removeBtn = field.querySelector('[data-role="remove-image"]');
@@ -48,7 +48,7 @@
             const errorLabel = field.querySelector('[data-role="image-error"]');
             const initialUrl = field.dataset.initialUrl || '';
 
-            if (!hiddenInput || !searchBtn) {
+            if (!urlInput || !searchBtn) {
                 return;
             }
 
@@ -71,13 +71,54 @@
                 }
             };
 
-            updatePreview(initialUrl);
+            const buildPreviewUrl = (value) => {
+                const raw = (value || '').trim();
+                if (!raw) {
+                    return '';
+                }
+
+                if (/^(?:https?:)?\/\//i.test(raw) || raw.startsWith('data:')) {
+                    return raw;
+                }
+
+                if (raw.startsWith('/')) {
+                    return raw;
+                }
+
+                const uploadsPrefix = 'uploads/';
+                const withoutUploads = raw.startsWith(uploadsPrefix) ? raw.slice(uploadsPrefix.length) : raw;
+                return `/static/${withoutUploads}`;
+            };
+
+            const syncPreviewWithInput = (overrideUrl) => {
+                if (typeof overrideUrl === 'string') {
+                    updatePreview(overrideUrl);
+                } else {
+                    updatePreview(buildPreviewUrl(urlInput.value));
+                }
+            };
+
+            if (initialUrl) {
+                updatePreview(initialUrl);
+            } else {
+                syncPreviewWithInput();
+            }
+
+            ['input', 'change'].forEach(evtName => {
+                urlInput.addEventListener(evtName, () => {
+                    syncPreviewWithInput();
+                    if (errorLabel) {
+                        errorLabel.textContent = '';
+                        errorLabel.classList.add('hidden');
+                    }
+                });
+            });
 
             if (removeBtn) {
                 removeBtn.addEventListener('click', (event) => {
                     event.preventDefault();
-                    hiddenInput.value = '';
-                    updatePreview('');
+                    urlInput.value = '';
+                    syncPreviewWithInput('');
                     if (errorLabel) {
                         errorLabel.textContent = '';
                         errorLabel.classList.add('hidden');
@@ -131,8 +172,8 @@
                     const result = await response.json();
 
                     if (response.ok && result && result.success && result.image_url) {
-                        hiddenInput.value = result.relative_path || '';
-                        updatePreview(result.image_url);
+                        urlInput.value = result.relative_path || '';
+                        syncPreviewWithInput(result.image_url);
                     } else {
                         const message = (result && result.message) || 'Không tìm thấy ảnh phù hợp.';
                         if (errorLabel) {

--- a/mindstack_app/modules/content_management/flashcards/templates/add_edit_flashcard_item.html
+++ b/mindstack_app/modules/content_management/flashcards/templates/add_edit_flashcard_item.html
@@ -88,9 +88,9 @@
                         </div>
                         <div data-image-side="front"
                              data-initial-url="{{ front_image_url or '' }}">
-                            {{ form.front_img(type='hidden', id=form.front_img.id, data_role='image-path') }}
                             {{ form.front_img.label(class="block text-sm font-medium text-gray-700") }}
-                            <div class="flex flex-col sm:flex-row gap-4 mt-2">
+                            {{ form.front_img(class="mt-1 block w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500", id=form.front_img.id, data_role='image-path', placeholder="URL hình ảnh mặt trước") }}
+                            <div class="flex flex-col sm:flex-row gap-4 mt-3">
                                 <div class="relative w-full sm:w-40 h-40 border border-dashed border-gray-300 rounded-lg flex items-center justify-center bg-gray-50 overflow-hidden" data-role="image-preview-wrapper">
                                     <img src="{{ front_image_url }}" alt="Hình ảnh mặt trước" class="max-h-full max-w-full {{ '' if front_image_url else 'hidden' }}" data-role="image-preview">
                                     <span class="text-gray-400 text-xs text-center px-2 {{ 'hidden' if front_image_url else '' }}" data-role="image-placeholder">Chưa có hình ảnh</span>
@@ -124,9 +124,9 @@
                         </div>
                         <div data-image-side="back"
                              data-initial-url="{{ back_image_url or '' }}">
-                            {{ form.back_img(type='hidden', id=form.back_img.id, data_role='image-path') }}
                             {{ form.back_img.label(class="block text-sm font-medium text-gray-700") }}
-                            <div class="flex flex-col sm:flex-row gap-4 mt-2">
+                            {{ form.back_img(class="mt-1 block w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500", id=form.back_img.id, data_role='image-path', placeholder="URL hình ảnh mặt sau") }}
+                            <div class="flex flex-col sm:flex-row gap-4 mt-3">
                                 <div class="relative w-full sm:w-40 h-40 border border-dashed border-gray-300 rounded-lg flex items-center justify-center bg-gray-50 overflow-hidden" data-role="image-preview-wrapper">
                                     <img src="{{ back_image_url }}" alt="Hình ảnh mặt sau" class="max-h-full max-w-full {{ '' if back_image_url else 'hidden' }}" data-role="image-preview">
                                     <span class="text-gray-400 text-xs text-center px-2 {{ 'hidden' if back_image_url else '' }}" data-role="image-placeholder">Chưa có hình ảnh</span>


### PR DESCRIPTION
## Summary
- expose the front and back image fields in the flashcard item forms so users can enter URLs manually
- update the flashcard image helper script to keep previews and remove buttons in sync with the manual URL value while preserving search behaviour

## Testing
- pytest tests -q

------
https://chatgpt.com/codex/tasks/task_e_68d748002ab48326bc63495349567279