### PR TITLE
Add flashcard audio preview and regeneration controls

### DIFF
--- a/mindstack_app/modules/content_management/flashcards/routes.py
+++ b/mindstack_app/modules/content_management/flashcards/routes.py
@@ -72,6 +72,29 @@ def _get_static_image_url(url):
     return url_for('static', filename=relative_path)
 
 
+def _get_static_audio_url(url):
+    """Chuyển đổi đường dẫn audio tương đối thành URL tĩnh đầy đủ."""
+    if not url:
+        return None
+
+    if isinstance(url, str):
+        normalized = url.strip()
+    else:
+        normalized = str(url).strip()
+
+    if not normalized:
+        return None
+
+    if normalized.startswith(('http://', 'https://', '/')):
+        return normalized
+
+    relative_path = normalized
+    if relative_path.startswith('uploads/'):
+        relative_path = relative_path.replace('uploads/', '', 1)
+
+    return url_for('static', filename=relative_path)
+
+
 def _has_editor_access(container_id):
     if current_user.user_role == User.ROLE_FREE:
         return False
@@ -583,10 +606,14 @@ def add_flashcard_item(set_id):
     context = {
         'form': form,
         'flashcard_set': flashcard_set,
+        'flashcard_item': None,
         'title': 'Thêm Thẻ',
         'front_image_url': _get_static_image_url(form.front_img.data),
         'back_image_url': _get_static_image_url(form.back_img.data),
-        'image_search_url': url_for('.search_flashcard_image', set_id=set_id, item_id=0)
+        'front_audio_url_resolved': _get_static_audio_url(form.front_audio_url.data),
+        'back_audio_url_resolved': _get_static_audio_url(form.back_audio_url.data),
+        'image_search_url': url_for('.search_flashcard_image', set_id=set_id, item_id=0),
+        'regenerate_audio_url': url_for('learning.flashcard_learning.regenerate_audio_from_content')
     }
 
     # Render template cho modal hoặc trang đầy đủ
@@ -687,7 +714,10 @@ def edit_flashcard_item(set_id, item_id):
         'title': 'Sửa Thẻ',
         'front_image_url': _get_static_image_url(form.front_img.data),
         'back_image_url': _get_static_image_url(form.back_img.data),
-        'image_search_url': url_for('.search_flashcard_image', set_id=set_id, item_id=item_id)
+        'front_audio_url_resolved': _get_static_audio_url(form.front_audio_url.data),
+        'back_audio_url_resolved': _get_static_audio_url(form.back_audio_url.data),
+        'image_search_url': url_for('.search_flashcard_image', set_id=set_id, item_id=item_id),
+        'regenerate_audio_url': url_for('learning.flashcard_learning.regenerate_audio_from_content')
     }
 
     # Render template cho modal hoặc trang đầy đủ

--- a/mindstack_app/modules/content_management/flashcards/templates/_add_edit_flashcard_item_bare.html
+++ b/mindstack_app/modules/content_management/flashcards/templates/_add_edit_flashcard_item_bare.html
@@ -52,7 +52,9 @@
                   class="space-y-6"
                   data-image-search-url="{{ image_search_url }}"
                   data-front-source-id="{{ form.front.id }}"
-                  data-back-source-id="{{ form.back.id }}">
+                  data-back-source-id="{{ form.back.id }}"
+                  data-item-id="{{ flashcard_item.item_id if flashcard_item else '' }}"
+                  data-regenerate-audio-url="{{ regenerate_audio_url }}">
                 {{ form.csrf_token }}
                 
                 <div>
@@ -88,6 +90,30 @@
                         <div>
                             {{ form.front_audio_url.label(class="block text-sm font-medium text-gray-700") }}
                             {{ form.front_audio_url(class="mt-1 block w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500", placeholder="URL file âm thanh mặt trước") }}
+                            <div class="mt-3 space-y-2"
+                                 data-audio-side="front"
+                                 data-audio-url-input-id="{{ form.front_audio_url.id }}"
+                                 data-audio-content-input-id="{{ form.front_audio_content.id }}"
+                                 data-initial-audio-url="{{ front_audio_url_resolved or '' }}">
+                                <div class="flex flex-wrap items-center gap-3">
+                                    <button type="button"
+                                            class="bg-green-500 hover:bg-green-600 text-white px-4 py-2 rounded-md transition duration-200 flex items-center"
+                                            data-role="play-audio">
+                                        <i class="fas fa-play mr-2"></i> Nghe thử
+                                    </button>
+                                    <button type="button"
+                                            class="bg-purple-500 hover:bg-purple-600 text-white px-4 py-2 rounded-md transition duration-200 flex items-center"
+                                            data-role="regenerate-audio">
+                                        <i class="fas fa-sync-alt mr-2"></i> Tái tạo audio
+                                    </button>
+                                    <span class="text-sm text-gray-500" data-role="audio-status"></span>
+                                </div>
+                                <audio controls preload="none"
+                                       class="w-full rounded-md border border-gray-200 {{ '' if front_audio_url_resolved else 'hidden' }}"
+                                       data-role="audio-player"{% if front_audio_url_resolved %} src="{{ front_audio_url_resolved }}"{% endif %}>
+                                    Trình duyệt của bạn không hỗ trợ phần tử audio.
+                                </audio>
+                            </div>
                         </div>
                         <div>
                             {{ form.back_audio_content.label(class="block text-sm font-medium text-gray-700") }}
@@ -96,6 +122,30 @@
                         <div>
                             {{ form.back_audio_url.label(class="block text-sm font-medium text-gray-700") }}
                             {{ form.back_audio_url(class="mt-1 block w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500", placeholder="URL file âm thanh mặt sau") }}
+                            <div class="mt-3 space-y-2"
+                                 data-audio-side="back"
+                                 data-audio-url-input-id="{{ form.back_audio_url.id }}"
+                                 data-audio-content-input-id="{{ form.back_audio_content.id }}"
+                                 data-initial-audio-url="{{ back_audio_url_resolved or '' }}">
+                                <div class="flex flex-wrap items-center gap-3">
+                                    <button type="button"
+                                            class="bg-green-500 hover:bg-green-600 text-white px-4 py-2 rounded-md transition duration-200 flex items-center"
+                                            data-role="play-audio">
+                                        <i class="fas fa-play mr-2"></i> Nghe thử
+                                    </button>
+                                    <button type="button"
+                                            class="bg-purple-500 hover:bg-purple-600 text-white px-4 py-2 rounded-md transition duration-200 flex items-center"
+                                            data-role="regenerate-audio">
+                                        <i class="fas fa-sync-alt mr-2"></i> Tái tạo audio
+                                    </button>
+                                    <span class="text-sm text-gray-500" data-role="audio-status"></span>
+                                </div>
+                                <audio controls preload="none"
+                                       class="w-full rounded-md border border-gray-200 {{ '' if back_audio_url_resolved else 'hidden' }}"
+                                       data-role="audio-player"{% if back_audio_url_resolved %} src="{{ back_audio_url_resolved }}"{% endif %}>
+                                    Trình duyệt của bạn không hỗ trợ phần tử audio.
+                                </audio>
+                            </div>
                         </div>
                         <div data-image-side="front"
                              data-initial-url="{{ front_image_url or '' }}">
@@ -190,6 +240,7 @@
 </div>
 
 {% include '_flashcard_image_control_scripts.html' %}
+{% include '_flashcard_audio_control_scripts.html' %}
 
 <script>
     document.addEventListener('DOMContentLoaded', function() {
@@ -239,6 +290,7 @@
         
         if (form) {
             initializeFlashcardImageControls({ form: form });
+            initializeFlashcardAudioControls({ form: form });
             {# Đặt action của form dựa trên URL hiện tại (để xử lý cả add và edit) #}
             const currentUrl = new URL(window.location.href);
             currentUrl.searchParams.delete('is_modal'); 

--- a/mindstack_app/modules/content_management/flashcards/templates/_flashcard_audio_control_scripts.html
+++ b/mindstack_app/modules/content_management/flashcards/templates/_flashcard_audio_control_scripts.html
@@ -1,0 +1,271 @@
+<script>
+(function() {
+    if (window.initializeFlashcardAudioControls) {
+        return;
+    }
+
+    window.initializeFlashcardAudioControls = function initializeFlashcardAudioControls(options) {
+        const opts = options || {};
+        const formElement = opts.form || (opts.formSelector ? document.querySelector(opts.formSelector) : null);
+        if (!formElement) {
+            return;
+        }
+
+        const itemId = opts.itemId || formElement.dataset.itemId || '';
+        const regenerateUrl = opts.regenerateUrl || formElement.dataset.regenerateAudioUrl || '';
+        const csrfInput = formElement.querySelector('input[name="csrf_token"]');
+        const csrfToken = csrfInput ? csrfInput.value : '';
+
+        const audioGroups = Array.from(formElement.querySelectorAll('[data-audio-side]'));
+        if (!audioGroups.length) {
+            return;
+        }
+
+        let currentAudio = null;
+
+        const stopCurrentAudio = () => {
+            if (currentAudio) {
+                currentAudio.pause();
+                currentAudio.currentTime = 0;
+                currentAudio = null;
+            }
+        };
+
+        const resolveAudioUrl = (value) => {
+            const raw = (value || '').trim();
+            if (!raw) {
+                return '';
+            }
+
+            if (/^(?:https?:)?\/\//i.test(raw) || raw.startsWith('data:')) {
+                return raw;
+            }
+
+            if (raw.startsWith('/')) {
+                return raw;
+            }
+
+            const uploadsPrefix = 'uploads/';
+            const withoutUploads = raw.startsWith(uploadsPrefix) ? raw.slice(uploadsPrefix.length) : raw;
+            return `/static/${withoutUploads}`;
+        };
+
+        const toInputValue = (url) => {
+            if (!url) {
+                return '';
+            }
+            const trimmed = url.trim();
+            const staticPrefix = '/static/';
+            if (trimmed.startsWith(staticPrefix)) {
+                return trimmed.slice(staticPrefix.length);
+            }
+            const originStatic = window.location.origin + staticPrefix;
+            if (trimmed.startsWith(originStatic)) {
+                return trimmed.slice(originStatic.length);
+            }
+            return trimmed;
+        };
+
+        audioGroups.forEach(group => {
+            const side = (group.dataset.audioSide || 'front').toLowerCase();
+            const audioElement = group.querySelector('audio[data-role="audio-player"]');
+            const playButton = group.querySelector('[data-role="play-audio"]');
+            const regenerateButton = group.querySelector('[data-role="regenerate-audio"]');
+            const statusLabel = group.querySelector('[data-role="audio-status"]');
+            const urlInputId = group.dataset.audioUrlInputId;
+            const contentInputId = group.dataset.audioContentInputId;
+            const initialUrl = group.dataset.initialAudioUrl || '';
+
+            const urlInput = urlInputId ? formElement.querySelector(`#${urlInputId}`) : null;
+            const contentInput = contentInputId ? formElement.querySelector(`#${contentInputId}`) : null;
+
+            if (!audioElement || !playButton) {
+                return;
+            }
+
+            const updateStatus = (message, type) => {
+                if (!statusLabel) {
+                    return;
+                }
+                statusLabel.textContent = message || '';
+                statusLabel.classList.remove('text-red-500', 'text-green-600', 'text-gray-500');
+                if (!message) {
+                    return;
+                }
+                if (type === 'error') {
+                    statusLabel.classList.add('text-red-500');
+                } else if (type === 'success') {
+                    statusLabel.classList.add('text-green-600');
+                } else {
+                    statusLabel.classList.add('text-gray-500');
+                }
+            };
+
+            const syncAudioWithInput = () => {
+                if (!urlInput) {
+                    return;
+                }
+                const resolved = resolveAudioUrl(urlInput.value);
+                if (resolved) {
+                    audioElement.src = resolved;
+                    audioElement.classList.remove('hidden');
+                } else {
+                    audioElement.pause();
+                    audioElement.removeAttribute('src');
+                    audioElement.load();
+                    audioElement.classList.add('hidden');
+                }
+            };
+
+            if (initialUrl) {
+                audioElement.src = initialUrl;
+                audioElement.classList.remove('hidden');
+            } else {
+                syncAudioWithInput();
+            }
+
+            if (urlInput) {
+                ['input', 'change'].forEach(evt => {
+                    urlInput.addEventListener(evt, () => {
+                        syncAudioWithInput();
+                        updateStatus('', '');
+                    });
+                });
+            }
+
+            playButton.addEventListener('click', () => {
+                const sourceUrl = urlInput ? resolveAudioUrl(urlInput.value) : (audioElement.getAttribute('src') || '');
+                if (!sourceUrl) {
+                    updateStatus('Chưa có audio. Vui lòng nhập URL hoặc tái tạo.', 'error');
+                    return;
+                }
+
+                if (currentAudio && currentAudio !== audioElement) {
+                    stopCurrentAudio();
+                }
+
+                audioElement.src = sourceUrl;
+                audioElement.play().then(() => {
+                    currentAudio = audioElement;
+                    updateStatus('Đang phát audio...', '');
+                }).catch(error => {
+                    console.error('Không thể phát audio:', error);
+                    updateStatus('Không thể phát audio. Vui lòng kiểm tra URL.', 'error');
+                });
+            });
+
+            audioElement.addEventListener('ended', () => {
+                if (currentAudio === audioElement) {
+                    currentAudio = null;
+                }
+                updateStatus('', '');
+            });
+
+            audioElement.addEventListener('pause', () => {
+                if (currentAudio === audioElement && Math.floor(audioElement.currentTime) === 0) {
+                    currentAudio = null;
+                    updateStatus('', '');
+                }
+            });
+
+            audioElement.addEventListener('error', () => {
+                updateStatus('Không thể tải audio. Vui lòng kiểm tra URL.', 'error');
+            });
+
+            if (regenerateButton) {
+                if (!regenerateUrl || !itemId) {
+                    regenerateButton.disabled = true;
+                    if (!regenerateUrl) {
+                        regenerateButton.title = 'Không tìm thấy đường dẫn tái tạo audio.';
+                    } else {
+                        regenerateButton.title = 'Vui lòng lưu thẻ trước khi tái tạo audio.';
+                    }
+                }
+
+                regenerateButton.addEventListener('click', async () => {
+                    if (!regenerateUrl || !itemId) {
+                        return;
+                    }
+
+                    const contentToRead = contentInput ? contentInput.value.trim() : '';
+                    if (!contentToRead) {
+                        updateStatus('Vui lòng nhập nội dung audio trước khi tái tạo.', 'error');
+                        if (contentInput) {
+                            contentInput.focus();
+                        }
+                        return;
+                    }
+
+                    const originalHtml = regenerateButton.dataset.originalHtml || regenerateButton.innerHTML;
+                    if (!regenerateButton.dataset.originalHtml) {
+                        regenerateButton.dataset.originalHtml = originalHtml;
+                    }
+
+                    regenerateButton.innerHTML = '<i class="fas fa-spinner fa-spin"></i>';
+                    regenerateButton.disabled = true;
+                    playButton.disabled = true;
+                    updateStatus('Đang tạo audio...', '');
+
+                    try {
+                        const response = await fetch(regenerateUrl, {
+                            method: 'POST',
+                            headers: {
+                                'Content-Type': 'application/json',
+                                'X-Requested-With': 'XMLHttpRequest',
+                                ...(csrfToken ? { 'X-CSRFToken': csrfToken } : {})
+                            },
+                            body: JSON.stringify({
+                                item_id: itemId,
+                                side,
+                                content_to_read: contentToRead
+                            })
+                        });
+
+                        const result = await response.json();
+
+                        if (response.ok && result && result.success && result.audio_url) {
+                            const resolved = result.audio_url;
+                            const inputValue = result.relative_path ? result.relative_path : toInputValue(resolved);
+                            if (urlInput) {
+                                urlInput.value = inputValue;
+                            }
+                            audioElement.src = resolved;
+                            audioElement.classList.remove('hidden');
+                            audioElement.load();
+                            updateStatus('Đã tạo audio mới.', 'success');
+                        } else {
+                            const message = (result && result.message) || 'Không thể tạo audio.';
+                            updateStatus(message, 'error');
+                        }
+                    } catch (error) {
+                        console.error('Lỗi khi tái tạo audio:', error);
+                        updateStatus('Không thể kết nối đến máy chủ.', 'error');
+                    } finally {
+                        regenerateButton.innerHTML = regenerateButton.dataset.originalHtml || originalHtml;
+                        if (regenerateUrl && itemId) {
+                            regenerateButton.disabled = false;
+                        }
+                        playButton.disabled = false;
+                    }
+                });
+            }
+        });
+
+        document.addEventListener('play', (event) => {
+            const target = event.target;
+            if (!(target instanceof HTMLAudioElement)) {
+                return;
+            }
+
+            if (!audioGroups.some(group => group.contains(target))) {
+                return;
+            }
+
+            if (currentAudio && currentAudio !== target) {
+                stopCurrentAudio();
+            }
+            currentAudio = target;
+        }, true);
+    };
+})();
+</script>

--- a/mindstack_app/modules/content_management/flashcards/templates/add_edit_flashcard_item.html
+++ b/mindstack_app/modules/content_management/flashcards/templates/add_edit_flashcard_item.html
@@ -24,7 +24,9 @@
                   class="space-y-6"
                   data-image-search-url="{{ image_search_url }}"
                   data-front-source-id="{{ form.front.id }}"
-                  data-back-source-id="{{ form.back.id }}">
+                  data-back-source-id="{{ form.back.id }}"
+                  data-item-id="{{ flashcard_item.item_id if flashcard_item else '' }}"
+                  data-regenerate-audio-url="{{ regenerate_audio_url }}">
                 {{ form.csrf_token }}
                 
                 <div>
@@ -67,6 +69,30 @@
                                     {% for error in form.front_audio_url.errors %}<p>{{ error }}</p>{% endfor %}
                                 </div>
                             {% endif %}
+                            <div class="mt-3 space-y-2"
+                                 data-audio-side="front"
+                                 data-audio-url-input-id="{{ form.front_audio_url.id }}"
+                                 data-audio-content-input-id="{{ form.front_audio_content.id }}"
+                                 data-initial-audio-url="{{ front_audio_url_resolved or '' }}">
+                                <div class="flex flex-wrap items-center gap-3">
+                                    <button type="button"
+                                            class="bg-green-500 hover:bg-green-600 text-white px-4 py-2 rounded-md transition duration-200 flex items-center"
+                                            data-role="play-audio">
+                                        <i class="fas fa-play mr-2"></i> Nghe thử
+                                    </button>
+                                    <button type="button"
+                                            class="bg-purple-500 hover:bg-purple-600 text-white px-4 py-2 rounded-md transition duration-200 flex items-center"
+                                            data-role="regenerate-audio">
+                                        <i class="fas fa-sync-alt mr-2"></i> Tái tạo audio
+                                    </button>
+                                    <span class="text-sm text-gray-500" data-role="audio-status"></span>
+                                </div>
+                                <audio controls preload="none"
+                                       class="w-full rounded-md border border-gray-200 {{ '' if front_audio_url_resolved else 'hidden' }}"
+                                       data-role="audio-player"{% if front_audio_url_resolved %} src="{{ front_audio_url_resolved }}"{% endif %}>
+                                    Trình duyệt của bạn không hỗ trợ phần tử audio.
+                                </audio>
+                            </div>
                         </div>
                         <div>
                             {{ form.back_audio_content.label(class="block text-sm font-medium text-gray-700") }}
@@ -85,6 +111,30 @@
                                     {% for error in form.back_audio_url.errors %}<p>{{ error }}</p>{% endfor %}
                                 </div>
                             {% endif %}
+                            <div class="mt-3 space-y-2"
+                                 data-audio-side="back"
+                                 data-audio-url-input-id="{{ form.back_audio_url.id }}"
+                                 data-audio-content-input-id="{{ form.back_audio_content.id }}"
+                                 data-initial-audio-url="{{ back_audio_url_resolved or '' }}">
+                                <div class="flex flex-wrap items-center gap-3">
+                                    <button type="button"
+                                            class="bg-green-500 hover:bg-green-600 text-white px-4 py-2 rounded-md transition duration-200 flex items-center"
+                                            data-role="play-audio">
+                                        <i class="fas fa-play mr-2"></i> Nghe thử
+                                    </button>
+                                    <button type="button"
+                                            class="bg-purple-500 hover:bg-purple-600 text-white px-4 py-2 rounded-md transition duration-200 flex items-center"
+                                            data-role="regenerate-audio">
+                                        <i class="fas fa-sync-alt mr-2"></i> Tái tạo audio
+                                    </button>
+                                    <span class="text-sm text-gray-500" data-role="audio-status"></span>
+                                </div>
+                                <audio controls preload="none"
+                                       class="w-full rounded-md border border-gray-200 {{ '' if back_audio_url_resolved else 'hidden' }}"
+                                       data-role="audio-player"{% if back_audio_url_resolved %} src="{{ back_audio_url_resolved }}"{% endif %}>
+                                    Trình duyệt của bạn không hỗ trợ phần tử audio.
+                                </audio>
+                            </div>
                         </div>
                         <div data-image-side="front"
                              data-initial-url="{{ front_image_url or '' }}">
@@ -192,12 +242,15 @@
 </div>
 {% endblock %}
 
+
 {% block scripts %}
 {{ super() }}
 {% include '_flashcard_image_control_scripts.html' %}
+{% include '_flashcard_audio_control_scripts.html' %}
 <script>
     document.addEventListener('DOMContentLoaded', function() {
         initializeFlashcardImageControls({ formSelector: '#flashcardItemForm' });
+        initializeFlashcardAudioControls({ formSelector: '#flashcardItemForm' });
     });
 </script>
 {% endblock %}

--- a/mindstack_app/modules/learning/flashcard_learning/routes.py
+++ b/mindstack_app/modules/learning/flashcard_learning/routes.py
@@ -575,11 +575,12 @@ def regenerate_audio_from_content():
             
             flag_modified(item, 'content')
             db.session.commit()
-            
+
             return jsonify({
                 'success': True,
                 'message': 'Đã tạo audio thành công.',
-                'audio_url': url_for('static', filename=relative_path)
+                'audio_url': url_for('static', filename=relative_path),
+                'relative_path': relative_path
             })
         else:
             return jsonify({'success': False, 'message': msg}), 500


### PR DESCRIPTION
## Summary
- add inline audio players and playback/regenerate buttons to both flashcard item form layouts
- introduce a reusable audio control script that manages playback, regeneration requests, and status updates
- expose resolved audio URLs from the backend and return relative paths when regenerating audio

## Testing
- pytest tests

------
https://chatgpt.com/codex/tasks/task_e_68d74915b0f88326a6e26d763e1b5d01