### PR TITLE
Adjust mobile flashcard action layout

### DIFF
--- a/mindstack_app/modules/learning/flashcard_learning/templates/flashcard_session.html
+++ b/mindstack_app/modules/learning/flashcard_learning/templates/flashcard_session.html
@@ -618,15 +618,32 @@
             gap: 0.65rem;
         }
 
+        .actions.visible {
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+
+        .actions[data-button-count="4"] .rating-btn:nth-child(4) {
+            grid-column: auto;
+        }
+
+        .actions .btn {
+            padding: 0.55rem 0.75rem;
+            font-size: 0.9rem;
+        }
+
         .rating-btn {
-            padding: 0.65rem 0.85rem;
-            gap: 0.45rem;
+            padding: 0.55rem 0.75rem;
+            gap: 0.4rem;
         }
 
         .rating-btn .rating-btn__icon {
-            width: 1.8rem;
-            height: 1.8rem;
-            font-size: 1rem;
+            width: 1.6rem;
+            height: 1.6rem;
+            font-size: 0.9rem;
+        }
+
+        .rating-btn .rating-btn__title {
+            font-size: 0.85rem;
         }
     }
 


### PR DESCRIPTION
## Summary
- update the mobile action grid to display buttons in two columns
- shrink button padding, text, and icon sizes for a compact mobile presentation

## Testing
- Manually verified the mobile layout at a 360px viewport width


------
https://chatgpt.com/codex/tasks/task_e_68d74f223e288326ac0b08ded42b8a86