### PR TITLE
Adjust flashcard action button grid layout

### DIFF
--- a/mindstack_app/modules/learning/flashcard_learning/templates/flashcard_session.html
+++ b/mindstack_app/modules/learning/flashcard_learning/templates/flashcard_session.html
@@ -472,8 +472,21 @@
 
     .actions.visible {
         display: grid;
-        grid-template-columns: repeat(3, minmax(0, 1fr));
+        grid-template-columns: repeat(auto-fit, minmax(0, 1fr));
+        grid-auto-rows: 1fr;
         align-items: stretch;
+    }
+
+    .actions.visible[data-button-count="3"] {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+
+    .actions.visible[data-button-count="4"] {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .actions.visible[data-button-count="6"] {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
     }
 
     .btn {
@@ -601,10 +614,6 @@
         text-align: center;
     }
 
-    .actions[data-button-count="4"] .rating-btn:nth-child(4) {
-        grid-column: 2 / span 1;
-    }
-
     @media (max-width: 1024px) {
         .actions {
             padding: 1rem 1.25rem;
@@ -616,14 +625,6 @@
         .actions {
             padding: 0.85rem 1rem;
             gap: 0.65rem;
-        }
-
-        .actions.visible {
-            grid-template-columns: repeat(2, minmax(0, 1fr));
-        }
-
-        .actions[data-button-count="4"] .rating-btn:nth-child(4) {
-            grid-column: auto;
         }
 
         .actions .btn {


### PR DESCRIPTION
## Summary
- update the flashcard action grid so 3 buttons stay on one row
- ensure 4 buttons render in a balanced 2x2 grid and 6 buttons in a 2x3 grid

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d7544c2a2c8326bf1965c514c0ef70