### PR TITLE
Support Markdown rendering for AI responses

### DIFF
--- a/mindstack_app/modules/ai_services/templates/ai_services/_ai_modal.html
+++ b/mindstack_app/modules/ai_services/templates/ai_services/_ai_modal.html
@@ -12,7 +12,7 @@
         </div>
         <div class="text-left space-y-4">
             <h4 id="ai-modal-term" class="text-sm font-semibold text-purple-600"></h4>
-            <div id="ai-response-container" class="prose max-w-none prose-sm bg-gray-50 p-4 rounded-md min-h-[150px] max-h-[40vh] overflow-y-auto">
+            <div id="ai-response-container" class="markdown-body bg-gray-50 p-4 rounded-md min-h-[150px] max-h-[40vh] overflow-y-auto">
                 <div class="text-gray-500">Câu trả lời của AI sẽ xuất hiện ở đây.</div>
             </div>
         </div>
@@ -77,7 +77,12 @@ async function fetchAiResponse() {
         })
         const result = await response.json()
         if (response.ok && result.success) {
-            aiResponseContainer.innerHTML = result.html_content || result.response
+            const rawContent = result.html_content || result.response || ''
+            if (window.applyMarkdownToElement) {
+                window.applyMarkdownToElement(aiResponseContainer, rawContent, { treatAsHtml: Boolean(result.html_content) })
+            } else {
+                aiResponseContainer.innerHTML = rawContent
+            }
         } else {
             aiResponseContainer.innerHTML = `<p class="text-red-500">${result.message || 'Có lỗi xảy ra.'}</p>`
         }

--- a/mindstack_app/modules/learning/quiz_learning/templates/quiz_session.html
+++ b/mindstack_app/modules/learning/quiz_learning/templates/quiz_session.html
@@ -320,6 +320,24 @@
             return tempDiv.innerHTML.replace(/\r?\n/g, '<br>');
         }
 
+        function renderMarkdownContent(text, options = {}) {
+            if (text === null || text === undefined) return '';
+            if (window.renderMarkdown) {
+                return window.renderMarkdown(text, options);
+            }
+            return formatTextForHtml(String(text));
+        }
+
+        function setMarkdownContent(element, text, options = {}) {
+            if (!element) return;
+            if (window.applyMarkdownToElement) {
+                window.applyMarkdownToElement(element, text, options);
+            } else {
+                element.innerHTML = renderMarkdownContent(text, options);
+                element.classList.add('markdown-body');
+            }
+        }
+
         function displayQuestionBatch(batchData) {
             currentQuestionBatch = batchData.items;
             userAnswers = {};
@@ -346,7 +364,11 @@
                 if (questionData.content.question_audio_file) {
                     mediaHtml += `<audio controls src="${formatTextForHtml(questionData.content.question_audio_file)}" class="w-full mb-4"></audio>`;
                 }
-                
+
+                const aiExplanationHtml = questionData.ai_explanation
+                    ? renderMarkdownContent(questionData.ai_explanation)
+                    : '<span class="italic text-gray-500">Chưa có giải thích từ AI.</span>';
+
                 fullBatchContentHtml += `
                     <div class="question-card" data-item-id="${questionData.item_id}">
                         <p class="text-gray-500 text-sm mb-2">Câu ${batchData.start_index + index + 1} / ${batchData.total_items_in_session}</p>
@@ -374,7 +396,7 @@
                             </div>
                             <div class="ai-explanation-section info-section" style="display: none;">
                                 <h4><i class="fas fa-robot text-blue-500"></i> Giải thích của AI</h4>
-                                <div class="content-display">${questionData.ai_explanation ? formatTextForHtml(questionData.ai_explanation) : '<span class="italic text-gray-500">Chưa có giải thích từ AI.</span>'}</div>
+                                <div class="content-display markdown-body">${aiExplanationHtml}</div>
                             </div>
                         </div>
 
@@ -433,9 +455,14 @@
                         const feedbackArea = questionCard.querySelector('.feedback-area');
                         let feedbackHtml = result.is_correct ? `<div class="feedback-box feedback-correct">Đáp án chính xác!</div>` : `<div class="feedback-box feedback-incorrect">Sai rồi. Đáp án đúng là ${formatTextForHtml(result.correct_answer)}.</div>`;
                         if (result.explanation) {
-                            feedbackHtml += `<div class="feedback-explanation"><strong>Giải thích:</strong> ${formatTextForHtml(result.explanation)}</div>`;
+                            feedbackHtml += `<div class="feedback-explanation"><strong>Giải thích:</strong> <div class="feedback-explanation-content mt-2"></div></div>`;
                         }
                         feedbackArea.innerHTML = feedbackHtml;
+
+                        if (result.explanation) {
+                            const explanationContent = feedbackArea.querySelector('.feedback-explanation-content');
+                            setMarkdownContent(explanationContent, result.explanation);
+                        }
 
                         questionCard.querySelectorAll('.option-button').forEach(button => {
                             button.classList.remove('selected');
@@ -528,10 +555,11 @@
                             });
                             const result = await response.json();
                             if (result.success) {
-                                contentDisplay.innerHTML = formatTextForHtml(result.response);
+                                const rawResponse = result.html_content || result.response || '';
+                                setMarkdownContent(contentDisplay, rawResponse, { treatAsHtml: Boolean(result.html_content) });
                                 // Cập nhật lại dữ liệu trong JS object để không phải gọi lại
                                 const questionInBatch = currentQuestionBatch.find(q => q.item_id == itemId);
-                                if (questionInBatch) questionInBatch.ai_explanation = result.response;
+                                if (questionInBatch) questionInBatch.ai_explanation = result.response || result.html_content || '';
                             } else {
                                 contentDisplay.innerHTML = `<span class="italic text-red-500">${result.message || 'Lỗi khi tạo giải thích.'}</span>`;
                             }

--- a/mindstack_app/modules/shared/templates/base.html
+++ b/mindstack_app/modules/shared/templates/base.html
@@ -16,8 +16,10 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
     
     <script src="https://cdn.tailwindcss.com"></script>
-    
+
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <script src="https://cdn.jsdelivr.net/npm/marked@9.1.4/marked.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.6/dist/purify.min.js"></script>
     
     <style>
         body {
@@ -118,7 +120,151 @@
                 display: block; /* Hiển thị lại trên desktop */
             }
         }
+
+        .markdown-body {
+            color: #1f2937;
+            font-size: 0.95rem;
+            line-height: 1.65;
+        }
+
+        .markdown-body p {
+            margin-top: 0;
+            margin-bottom: 0.75rem;
+        }
+
+        .markdown-body ul,
+        .markdown-body ol {
+            margin: 0.75rem 0 0.75rem 1.5rem;
+        }
+
+        .markdown-body ul {
+            list-style-type: disc;
+        }
+
+        .markdown-body ol {
+            list-style-type: decimal;
+        }
+
+        .markdown-body li + li {
+            margin-top: 0.35rem;
+        }
+
+        .markdown-body h1,
+        .markdown-body h2,
+        .markdown-body h3,
+        .markdown-body h4,
+        .markdown-body h5,
+        .markdown-body h6 {
+            color: #111827;
+            font-weight: 700;
+            margin-top: 1.25rem;
+            margin-bottom: 0.75rem;
+        }
+
+        .markdown-body h1 { font-size: 1.75rem; }
+        .markdown-body h2 { font-size: 1.5rem; }
+        .markdown-body h3 { font-size: 1.3rem; }
+        .markdown-body h4 { font-size: 1.1rem; }
+        .markdown-body h5 { font-size: 1rem; }
+        .markdown-body h6 { font-size: 0.95rem; }
+
+        .markdown-body blockquote {
+            border-left: 4px solid #c4c4c4;
+            margin: 1rem 0;
+            padding: 0.75rem 1rem;
+            background-color: #f3f4f6;
+            border-radius: 0.5rem;
+        }
+
+        .markdown-body code {
+            background-color: #f3f4f6;
+            border-radius: 0.25rem;
+            padding: 0.15rem 0.35rem;
+            font-size: 0.9em;
+        }
+
+        .markdown-body pre {
+            background-color: #111827;
+            color: #f9fafb;
+            padding: 1rem;
+            border-radius: 0.75rem;
+            overflow-x: auto;
+            margin: 1rem 0;
+            font-size: 0.9rem;
+        }
+
+        .markdown-body table {
+            width: 100%;
+            border-collapse: collapse;
+            margin: 1rem 0;
+        }
+
+        .markdown-body th,
+        .markdown-body td {
+            border: 1px solid #d1d5db;
+            padding: 0.5rem 0.75rem;
+            text-align: left;
+        }
+
+        .markdown-body th {
+            background-color: #f3f4f6;
+            font-weight: 600;
+        }
     </style>
+    <script>
+        (function() {
+            const fallbackFormat = (text) => {
+                if (text === null || text === undefined) {
+                    return '';
+                }
+                const div = document.createElement('div');
+                div.textContent = String(text);
+                return div.innerHTML.replace(/\r?\n/g, '<br>');
+            };
+
+            if (window.marked && typeof window.marked.setOptions === 'function') {
+                window.marked.setOptions({
+                    gfm: true,
+                    breaks: true,
+                    mangle: false,
+                    headerIds: false
+                });
+            }
+
+            window.renderMarkdown = function(text, options = {}) {
+                const { treatAsHtml = false } = options;
+                if (text === null || text === undefined) {
+                    return '';
+                }
+
+                const value = String(text);
+
+                try {
+                    if (treatAsHtml) {
+                        return window.DOMPurify ? window.DOMPurify.sanitize(value) : value;
+                    }
+
+                    if (window.marked && typeof window.marked.parse === 'function') {
+                        const rawHtml = window.marked.parse(value);
+                        return window.DOMPurify ? window.DOMPurify.sanitize(rawHtml) : rawHtml;
+                    }
+                } catch (err) {
+                    console.warn('Không thể hiển thị Markdown:', err);
+                }
+
+                return fallbackFormat(value);
+            };
+
+            window.applyMarkdownToElement = function(element, text, options = {}) {
+                if (!element) return;
+                const html = window.renderMarkdown ? window.renderMarkdown(text, options) : fallbackFormat(text);
+                element.innerHTML = html;
+                element.classList.add('markdown-body');
+            };
+
+            window.escapeTextWithBreaks = fallbackFormat;
+        })();
+    </script>
     {% block head %}{% endblock %}
 </head>
 <body class="bg-gray-100 flex flex-col min-h-screen{% block body_class %}{% endblock %}">


### PR DESCRIPTION
## Summary
- add a shared Markdown rendering helper backed by marked.js and DOMPurify with custom styling
- render flashcard AI modal responses and quiz AI explanations using the shared helper for rich formatting
- enhance quiz feedback handling to display generated explanations with Markdown-aware styling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d757ab4ee08326bac87c374c421832