### PR TITLE
Refresh flashcard session after item edits

### DIFF
--- a/mindstack_app/modules/content_management/flashcards/routes.py
+++ b/mindstack_app/modules/content_management/flashcards/routes.py
@@ -594,7 +594,11 @@ def add_flashcard_item(set_id):
         
         # Trả về phản hồi JSON hoặc chuyển hướng tùy theo yêu cầu
         if request.headers.get('X-Requested-With') == 'XMLHttpRequest':
-            return jsonify({'success': True, 'message': 'Thẻ mới đã được thêm!'})
+            return jsonify({
+                'success': True,
+                'message': 'Thẻ mới đã được thêm!',
+                'item_id': new_item.item_id
+            })
         else:
             flash('Thẻ mới đã được thêm!', 'success')
             return redirect(url_for('.list_flashcard_items', set_id=set_id))
@@ -688,7 +692,11 @@ def edit_flashcard_item(set_id, item_id):
         
         # Trả về phản hồi JSON hoặc chuyển hướng tùy theo yêu cầu
         if request.headers.get('X-Requested-With') == 'XMLHttpRequest':
-            return jsonify({'success': True, 'message': 'Thẻ đã được cập nhật!'})
+            return jsonify({
+                'success': True,
+                'message': 'Thẻ đã được cập nhật!',
+                'item_id': flashcard_item.item_id
+            })
         else:
             flash('Thẻ đã được cập nhật!', 'success')
             return redirect(url_for('.list_flashcard_items', set_id=set_id))

--- a/mindstack_app/modules/content_management/flashcards/templates/_add_edit_flashcard_item_bare.html
+++ b/mindstack_app/modules/content_management/flashcards/templates/_add_edit_flashcard_item_bare.html
@@ -248,7 +248,8 @@
         const aiRegenerateBtn = document.getElementById('ai-regenerate-btn');
         const aiExplanationField = document.getElementById('ai_explanation');
         const getAiResponseUrl = "{{ url_for('ai_services.get_ai_response') }}";
-        const itemId = "{{ flashcard_item.item_id | default('None') }}";
+        let currentItemId = {{ (flashcard_item.item_id if flashcard_item else None) | tojson }};
+        const setId = {{ flashcard_set.container_id | tojson }};
 
         if (aiRegenerateBtn) {
             aiRegenerateBtn.addEventListener('click', async function() {
@@ -258,7 +259,7 @@
                 aiExplanationField.value = "Đang tạo lại nội dung...";
 
                 const payload = {
-                    item_id: itemId,
+                    item_id: currentItemId,
                     prompt_type: 'explanation',
                     force_regenerate: true
                 };
@@ -293,7 +294,7 @@
             initializeFlashcardAudioControls({ form: form });
             {# Đặt action của form dựa trên URL hiện tại (để xử lý cả add và edit) #}
             const currentUrl = new URL(window.location.href);
-            currentUrl.searchParams.delete('is_modal'); 
+            currentUrl.searchParams.delete('is_modal');
             form.action = currentUrl.toString();
 
             form.addEventListener('submit', async function(event) {
@@ -319,19 +320,28 @@
 
                     if (response.ok) { {# HTTP status 200-299 #}
                         if (result.success) {
+                            if (typeof result.item_id !== 'undefined' && result.item_id !== null) {
+                                currentItemId = result.item_id;
+                                form.dataset.itemId = String(result.item_id);
+                            }
                             {# Thông báo thành công qua parent window (base.html) #}
                             if (window.parent && window.parent.showFlashMessage) {
                                 window.parent.showFlashMessage(result.message, 'success');
                             }
+                            const resolvedItemId = currentItemId || result.item_id;
+                            if (window.parent && typeof window.parent.updateFlashcardCard === 'function') {
+                                if (resolvedItemId) {
+                                    try {
+                                        await window.parent.updateFlashcardCard(resolvedItemId, setId);
+                                    } catch (updateError) {
+                                        console.error('Không thể cập nhật thẻ trong phiên học:', updateError);
+                                    }
+                                } else if (window.parent.showFlashMessage) {
+                                    window.parent.showFlashMessage('Không thể xác định thẻ vừa chỉnh sửa để làm mới trong phiên học.', 'warning');
+                                }
+                            }
                             {# Đóng modal #}
                             if (window.parent && window.parent.closeModal) {
-                                window.parent.closeModal();
-                            }
-                            {# Cập nhật thẻ hiện tại mà không tải lại trang #}
-                            if (window.parent.updateFlashcardCard) {
-                                // Assume we have a function to update the current card content on the parent page
-                                // This is a placeholder, as the parent doesn't have this function yet.
-                                // We'll just close the modal for now.
                                 window.parent.closeModal();
                             }
                             {# THAY ĐỔI: không tải lại trang #}

--- a/mindstack_app/modules/learning/flashcard_learning/templates/flashcard_session.html
+++ b/mindstack_app/modules/learning/flashcard_learning/templates/flashcard_session.html
@@ -874,6 +874,7 @@
     const statsModalBody = document.getElementById('statsModalBody');
 
     const getFlashcardBatchUrl = "{{ url_for('learning.flashcard_learning.get_flashcard_batch') }}";
+    const flashcardItemApiUrlTemplate = "{{ url_for('learning.flashcard_learning.get_flashcard_item_api', item_id=0) }}";
     const submitAnswerUrl = "{{ url_for('learning.flashcard_learning.submit_flashcard_answer') }}";
     const endSessionUrl = "{{ url_for('learning.flashcard_learning.end_session_flashcard') }}";
     const regenerateAudioUrl = "{{ url_for('learning.flashcard_learning.regenerate_audio_from_content') }}";
@@ -1786,6 +1787,74 @@
         container.innerHTML = html;
         initializeStatsToggleListeners(container);
     }
+
+    window.updateFlashcardCard = async function(itemId, setId) {
+        const numericItemId = Number(itemId);
+        const numericSetId = Number(setId);
+
+        if (!Number.isInteger(numericItemId) || numericItemId <= 0) {
+            const message = 'Không thể xác định thẻ cần cập nhật.';
+            if (window.showFlashMessage) {
+                window.showFlashMessage(message, 'warning');
+            }
+            throw new Error(message);
+        }
+
+        const apiUrl = flashcardItemApiUrlTemplate.replace('/0', `/${numericItemId}`);
+
+        try {
+            const response = await fetch(apiUrl, { headers: { 'X-Requested-With': 'XMLHttpRequest' } });
+            let payload = null;
+
+            try {
+                payload = await response.json();
+            } catch (parseError) {
+                payload = null;
+            }
+
+            if (!response.ok || !payload || !payload.success || !payload.item) {
+                const errorMessage = (payload && payload.message) ? payload.message : 'Không thể tải lại thẻ sau khi chỉnh sửa.';
+                throw new Error(errorMessage);
+            }
+
+            const updatedItem = payload.item;
+
+            if (Number.isInteger(numericSetId) && updatedItem.container_id !== numericSetId) {
+                const message = 'Thẻ vừa chỉnh sửa không thuộc bộ hiện tại.';
+                if (window.showFlashMessage) {
+                    window.showFlashMessage(message, 'warning');
+                }
+                return updatedItem;
+            }
+
+            const targetIndex = currentFlashcardBatch.findIndex(card => Number(card.item_id) === Number(updatedItem.item_id));
+
+            if (targetIndex === -1) {
+                const message = 'Không tìm thấy thẻ đang hiển thị trong phiên để cập nhật.';
+                if (window.showFlashMessage) {
+                    window.showFlashMessage(message, 'info');
+                }
+                return updatedItem;
+            }
+
+            currentFlashcardBatch[targetIndex] = updatedItem;
+
+            if (targetIndex === currentFlashcardIndex) {
+                stopAllFlashcardAudio();
+                renderCard(updatedItem);
+                const initialStatsHtml = renderCardStatsHtml(updatedItem.initial_stats, 0, updatedItem.content, true);
+                displayCardStats(currentCardStatsContainer, initialStatsHtml);
+            }
+
+            return updatedItem;
+        } catch (error) {
+            console.error('Không thể tải lại thẻ sau khi chỉnh sửa:', error);
+            if (window.showFlashMessage) {
+                window.showFlashMessage(error.message || 'Không thể tải lại thẻ sau khi chỉnh sửa.', 'danger');
+            }
+            throw error;
+        }
+    };
 
     async function getNextFlashcardBatch(){
       stopAllFlashcardAudio();


### PR DESCRIPTION
## Summary
- include the edited flashcard ID in AJAX responses from add/edit endpoints and notify the parent frame so it can refresh the card in-session
- expose a flashcard item JSON API that mirrors session batch data with absolute media URLs and initial statistics, then use it from the learning session to refresh card content and stats with error messaging

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d77256cd9c83268c536bebc0e5b767