### PR TITLE
Normalize relative media URLs

### DIFF
--- a/mindstack_app/modules/content_management/flashcards/routes.py
+++ b/mindstack_app/modules/content_management/flashcards/routes.py
@@ -37,17 +37,25 @@ def _apply_is_public_restrictions(form):
         existing_render_kw['disabled'] = True
         form.is_public.render_kw = existing_render_kw
 
+STATIC_RELATIVE_PREFIXES = ('uploads/',)
+
+
 def _process_relative_url(url):
-    """
-    Mô tả: Tiền xử lý URL tương đối, thêm 'uploads/' nếu cần.
-    Args:
-        url (str): URL ban đầu.
-    Returns:
-        str: URL đã được tiền xử lý.
-    """
-    if url and not url.startswith(('http://', 'https://', '/')):
-        return f'uploads/{url}'
-    return url
+    """Chuẩn hóa đường dẫn tương đối và thêm tiền tố tĩnh khi cần."""
+    if url is None:
+        return None
+
+    normalized = str(url).strip()
+    if not normalized:
+        return ''
+
+    if normalized.startswith(('http://', 'https://', '/')):
+        return normalized
+
+    if normalized.startswith(STATIC_RELATIVE_PREFIXES):
+        return normalized
+
+    return f'uploads/{normalized}'
 
 
 def _get_static_image_url(url):

--- a/mindstack_app/modules/content_management/quizzes/routes.py
+++ b/mindstack_app/modules/content_management/quizzes/routes.py
@@ -28,17 +28,25 @@ def _apply_is_public_restrictions(form):
         existing_render_kw['disabled'] = True
         form.is_public.render_kw = existing_render_kw
 
+STATIC_RELATIVE_PREFIXES = ('uploads/',)
+
+
 def _process_relative_url(url):
-    """
-    Mô tả: Tiền xử lý URL tương đối, thêm 'uploads/' nếu cần.
-    Args:
-        url (str): URL ban đầu.
-    Returns:
-        str: URL đã được tiền xử lý.
-    """
-    if url and not url.startswith(('http://', 'https://', '/')):
-        return f'uploads/{url}'
-    return url
+    """Chuẩn hóa đường dẫn tương đối và thêm tiền tố tĩnh khi cần."""
+    if url is None:
+        return None
+
+    normalized = str(url).strip()
+    if not normalized:
+        return ''
+
+    if normalized.startswith(('http://', 'https://', '/')):
+        return normalized
+
+    if normalized.startswith(STATIC_RELATIVE_PREFIXES):
+        return normalized
+
+    return f'uploads/{normalized}'
 
 
 def _build_absolute_media_url(file_path):


### PR DESCRIPTION
## Summary
- trim and normalize relative media URLs for flashcard content without duplicating static prefixes
- apply the same normalization guard to quiz media URL processing

## Testing
- python - <<'PY'
from mindstack_app.modules.content_management.flashcards.routes import _process_relative_url as flashcard_process
from mindstack_app.modules.content_management.quizzes.routes import _process_relative_url as quiz_process

samples = [
    None,
    '',
    '   ',
    'uploads/example.png',
    '   uploads/example.png   ',
    'flashcard/images/cache/foo.jpg',
    'http://example.com/image.png',
    '/static/image.png',
]

print('Flashcards:')
for value in samples:
    print(repr(value), '->', repr(flashcard_process(value)))

print('\nQuizzes:')
for value in samples:
    print(repr(value), '->', repr(quiz_process(value)))
PY

------
https://chatgpt.com/codex/tasks/task_e_68d7a8758c9c832684652dc99e834f28