### PR TITLE
Stop auto-prefixing relative media URLs in content managers

### DIFF
--- a/mindstack_app/modules/content_management/flashcards/routes.py
+++ b/mindstack_app/modules/content_management/flashcards/routes.py
@@ -37,9 +37,6 @@ def _apply_is_public_restrictions(form):
         existing_render_kw['disabled'] = True
         form.is_public.render_kw = existing_render_kw
 
-STATIC_RELATIVE_PREFIXES = ('uploads/',)
-
-
 def _process_relative_url(url):
     """Chuẩn hóa đường dẫn tương đối và thêm tiền tố tĩnh khi cần."""
     if url is None:
@@ -49,13 +46,7 @@ def _process_relative_url(url):
     if not normalized:
         return ''
 
-    if normalized.startswith(('http://', 'https://', '/')):
-        return normalized
-
-    if normalized.startswith(STATIC_RELATIVE_PREFIXES):
-        return normalized
-
-    return f'uploads/{normalized}'
+    return normalized
 
 
 def _get_static_image_url(url):

--- a/mindstack_app/modules/content_management/quizzes/routes.py
+++ b/mindstack_app/modules/content_management/quizzes/routes.py
@@ -28,9 +28,6 @@ def _apply_is_public_restrictions(form):
         existing_render_kw['disabled'] = True
         form.is_public.render_kw = existing_render_kw
 
-STATIC_RELATIVE_PREFIXES = ('uploads/',)
-
-
 def _process_relative_url(url):
     """Chuẩn hóa đường dẫn tương đối và thêm tiền tố tĩnh khi cần."""
     if url is None:
@@ -40,13 +37,7 @@ def _process_relative_url(url):
     if not normalized:
         return ''
 
-    if normalized.startswith(('http://', 'https://', '/')):
-        return normalized
-
-    if normalized.startswith(STATIC_RELATIVE_PREFIXES):
-        return normalized
-
-    return f'uploads/{normalized}'
+    return normalized
 
 
 def _build_absolute_media_url(file_path):


### PR DESCRIPTION
## Summary
- return flashcard and quiz media URLs exactly as entered without forcing an uploads/ prefix
- keep whitespace trimming so users can provide any relative or absolute path they prefer

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7a6aae8848326947f682091f3c553