### PR TITLE
Adjust flashcard session stats spacing and hide desktop scrollbar

### DIFF
--- a/mindstack_app/modules/learning/flashcard_learning/templates/_flashcard_session_stats.html
+++ b/mindstack_app/modules/learning/flashcard_learning/templates/_flashcard_session_stats.html
@@ -227,7 +227,7 @@
     .stats-tab-pane {
         display: none;
         flex-direction: column;
-        gap: 1.25rem;
+        gap: 1.6rem;
         flex: 1;
     }
 
@@ -239,6 +239,11 @@
         display: flex;
         flex-direction: column;
         gap: 0.75rem;
+    }
+
+    .stats-section + .stats-section {
+        margin-top: 1.1rem;
+        padding-top: 1.1rem;
     }
 
     .stats-section__header {
@@ -724,6 +729,21 @@
     .statistics-card--modal {
         max-height: none;
         overflow: visible;
+    }
+
+    @media (min-width: 1024px) {
+        .session-layout > .statistics-card {
+            -ms-overflow-style: none;
+            scrollbar-width: none;
+        }
+
+        .session-layout > .statistics-card::-webkit-scrollbar {
+            display: none;
+        }
+
+        .session-layout > .statistics-card {
+            scrollbar-color: auto;
+        }
     }
 
     @media (max-width: 1280px) {


### PR DESCRIPTION
## Summary
- hide the desktop scrollbar on the flashcard session statistics panel while keeping scrolling available on mobile
- add extra spacing between major statistics sections to visually separate key metrics

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7ae5d2bb88326ac244fbadb5690d0