### PR TITLE
Fix flashcard session layout overflow

### DIFF
--- a/mindstack_app/modules/learning/flashcard_learning/templates/flashcard_session.html
+++ b/mindstack_app/modules/learning/flashcard_learning/templates/flashcard_session.html
@@ -74,6 +74,7 @@
         align-items: stretch;
         min-height: 0;
         flex-grow: 1;
+        box-sizing: border-box;
         /* THAY ĐỔI: Cố định layout */
         overflow: hidden;
     }


### PR DESCRIPTION
## Summary
- ensure the flashcard session grid layout uses border-box sizing so padding no longer creates a stray scrollbar

## Testing
- No tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7b0a6bc9c8326ab06c8d8fb7265c1