### PR TITLE
Tighten flashcard session layout container sizing

### DIFF
--- a/mindstack_app/modules/learning/flashcard_learning/templates/flashcard_session.html
+++ b/mindstack_app/modules/learning/flashcard_learning/templates/flashcard_session.html
@@ -34,10 +34,23 @@
         overflow: hidden;
     }
 
+    body.flashcard-session-active > main {
+        padding: 0 !important;
+        margin: 0;
+        width: 100%;
+        max-width: none;
+        display: flex;
+        flex-direction: column;
+        flex: 1 1 auto;
+        min-height: 0;
+        overflow: hidden;
+    }
+
     .page-shell {
         display: flex;
         flex-direction: column;
-        height: calc(var(--vh, 1vh) * 100);
+        flex: 1 1 auto;
+        min-height: 0;
         padding: 0;
         overflow: hidden;
     }
@@ -74,6 +87,7 @@
         align-items: stretch;
         min-height: 0;
         flex-grow: 1;
+        box-sizing: border-box;
         /* THAY ĐỔI: Cố định layout */
         overflow: hidden;
     }
@@ -84,6 +98,7 @@
             top: var(--header-h, 0px);
             bottom: 0;
             padding: 0;
+            height: calc(var(--vh, 1vh) * 100);
         }
         .session-layout {
             display: flex;


### PR DESCRIPTION
## Summary
- ensure the flashcard session grid layout uses border-box sizing so padding no longer creates a stray scrollbar
- override the flashcard session container to stretch without extra padding so the viewport no longer shows a vertical scrollbar

## Testing
- No tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7b0a6bc9c8326ab06c8d8fb7265c1