### PR TITLE
Add export packages and Excel update flows for flashcards and quizzes

### DIFF
--- a/mindstack_app/modules/content_management/flashcards/routes.py
+++ b/mindstack_app/modules/content_management/flashcards/routes.py
@@ -5,7 +5,18 @@
 # ĐÃ SỬA: Bổ sung logic vào add_flashcard_item để chèn thẻ vào vị trí cụ thể.
 # ĐÃ SỬA: Bổ sung logic vào edit_flashcard_item để thay đổi vị trí thẻ và cập nhật lại thứ tự các thẻ khác.
 
-from flask import Blueprint, render_template, request, redirect, url_for, flash, abort, jsonify, current_app
+from flask import (
+    Blueprint,
+    render_template,
+    request,
+    redirect,
+    url_for,
+    flash,
+    abort,
+    jsonify,
+    current_app,
+    send_file,
+)
 from flask_login import login_required, current_user
 from sqlalchemy import or_
 from sqlalchemy.orm.attributes import flag_modified
@@ -15,6 +26,10 @@ import pandas as pd
 import tempfile
 import os
 import asyncio
+import zipfile
+import shutil
+import re
+import io
 from ....modules.shared.utils.pagination import get_pagination_data
 from ....modules.shared.utils.search import apply_search_filter
 # THÊM MỚI: Import AudioService
@@ -92,6 +107,81 @@ def _get_static_audio_url(url):
         relative_path = relative_path.replace('uploads/', '', 1)
 
     return url_for('static', filename=relative_path)
+
+
+def _slugify_filename(value: str) -> str:
+    """Chuyển tiêu đề thành chuỗi thân thiện để đặt tên file zip."""
+    value = (value or '').strip().lower()
+    if not value:
+        return 'flashcard-set'
+    value = re.sub(r'[^a-z0-9\-]+', '-', value)
+    value = re.sub(r'-{2,}', '-', value).strip('-')
+    return value or 'flashcard-set'
+
+
+def _resolve_local_media_path(path_value: str):
+    """Trả về đường dẫn tuyệt đối tới file media nếu thuộc thư mục uploads/static."""
+    if not path_value:
+        return None
+
+    normalized = str(path_value).strip()
+    if not normalized:
+        return None
+
+    if normalized.startswith(('http://', 'https://')):
+        return None
+
+    # Nếu đường dẫn bắt đầu bằng /static, thử map tới thư mục static
+    base_static = os.path.join(current_app.root_path, 'static')
+    candidates = []
+    if normalized.startswith('/'):
+        candidates.append(os.path.join(base_static, normalized.lstrip('/')))
+    else:
+        upload_folder = current_app.config.get('UPLOAD_FOLDER')
+        if upload_folder:
+            candidates.append(os.path.join(upload_folder, normalized))
+        candidates.append(os.path.join(base_static, normalized))
+
+    for candidate in candidates:
+        if candidate and os.path.isfile(candidate):
+            return candidate
+
+    return None
+
+
+def _copy_media_into_package(original_path: str, media_dir: str, existing_map: dict) -> str:
+    """Sao chép file media vào thư mục tạm và trả về đường dẫn tương đối trong gói."""
+    if not original_path:
+        return original_path
+
+    normalized = str(original_path).strip()
+    if not normalized:
+        return ''
+
+    if normalized.startswith(('http://', 'https://')):
+        return normalized
+
+    local_path = _resolve_local_media_path(normalized)
+    if not local_path:
+        return normalized
+
+    if local_path in existing_map:
+        return existing_map[local_path]
+
+    os.makedirs(media_dir, exist_ok=True)
+    filename = os.path.basename(local_path)
+    name, ext = os.path.splitext(filename)
+    candidate = filename
+    counter = 1
+    while os.path.exists(os.path.join(media_dir, candidate)):
+        candidate = f"{name}_{counter}{ext}"
+        counter += 1
+
+    destination = os.path.join(media_dir, candidate)
+    shutil.copy2(local_path, destination)
+    relative_in_zip = os.path.join('media', candidate).replace('\\', '/')
+    existing_map[local_path] = relative_in_zip
+    return relative_in_zip
 
 
 def _has_editor_access(container_id):
@@ -207,6 +297,77 @@ def list_flashcard_sets():
         return render_template('_flashcard_sets_list.html', **template_vars)
     else:
         return render_template('flashcard_sets.html', **template_vars)
+
+
+@flashcards_bp.route('/flashcards/<int:set_id>/export', methods=['GET'])
+@login_required
+def export_flashcard_set(set_id):
+    """Xuất bộ flashcard thành gói zip gồm Excel và media."""
+    flashcard_set = LearningContainer.query.get_or_404(set_id)
+
+    if current_user.user_role not in {User.ROLE_ADMIN} and flashcard_set.creator_user_id != current_user.user_id:
+        if current_user.user_role == User.ROLE_FREE or not _has_editor_access(set_id):
+            abort(403)
+
+    items = (
+        LearningItem.query.filter_by(container_id=set_id, item_type='FLASHCARD')
+        .order_by(LearningItem.order_in_container, LearningItem.item_id)
+        .all()
+    )
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        media_dir = os.path.join(tmp_dir, 'media')
+        os.makedirs(media_dir, exist_ok=True)
+        media_cache = {}
+
+        info_rows = [
+            {'Key': 'title', 'Value': flashcard_set.title},
+            {'Key': 'description', 'Value': flashcard_set.description or ''},
+            {'Key': 'tags', 'Value': flashcard_set.tags or ''},
+            {'Key': 'is_public', 'Value': str(flashcard_set.is_public)},
+        ]
+
+        if flashcard_set.ai_settings:
+            info_rows.append({'Key': 'ai_prompt', 'Value': flashcard_set.ai_settings.get('custom_prompt', '')})
+
+        data_rows = []
+        for item in items:
+            content = item.content or {}
+            row = {
+                'item_id': item.item_id,
+                'order_in_container': item.order_in_container,
+                'front': content.get('front'),
+                'back': content.get('back'),
+                'front_audio_content': content.get('front_audio_content'),
+                'back_audio_content': content.get('back_audio_content'),
+                'front_audio_url': _copy_media_into_package(content.get('front_audio_url'), media_dir, media_cache),
+                'back_audio_url': _copy_media_into_package(content.get('back_audio_url'), media_dir, media_cache),
+                'front_img': _copy_media_into_package(content.get('front_img'), media_dir, media_cache),
+                'back_img': _copy_media_into_package(content.get('back_img'), media_dir, media_cache),
+                'ai_explanation': content.get('ai_explanation'),
+                'ai_prompt': content.get('ai_prompt'),
+                'action': '',
+            }
+            data_rows.append(row)
+
+        excel_path = os.path.join(tmp_dir, 'flashcards.xlsx')
+        with pd.ExcelWriter(excel_path, engine='openpyxl') as writer:
+            pd.DataFrame(info_rows).to_excel(writer, sheet_name='Info', index=False)
+            pd.DataFrame(data_rows).to_excel(writer, sheet_name='Data', index=False)
+
+        zip_buffer = io.BytesIO()
+        with zipfile.ZipFile(zip_buffer, 'w', zipfile.ZIP_DEFLATED) as zipf:
+            zipf.write(excel_path, arcname='flashcards.xlsx')
+            if os.path.isdir(media_dir):
+                for root_dir, _, files in os.walk(media_dir):
+                    for filename in files:
+                        file_path = os.path.join(root_dir, filename)
+                        arcname = os.path.relpath(file_path, tmp_dir)
+                        zipf.write(file_path, arcname)
+
+        zip_buffer.seek(0)
+        download_name = f"{_slugify_filename(flashcard_set.title)}.zip"
+        return send_file(zip_buffer, as_attachment=True, download_name=download_name, mimetype='application/zip')
 
 @flashcards_bp.route('/flashcards/add', methods=['GET', 'POST'])
 @login_required
@@ -335,32 +496,154 @@ def edit_flashcard_set(set_id):
                 with tempfile.NamedTemporaryFile(delete=False, suffix='.xlsx') as tmp_file:
                     excel_file.save(tmp_file.name)
                     temp_filepath = tmp_file.name
+
                 df = pd.read_excel(temp_filepath, sheet_name='Data')
                 required_cols = ['front', 'back']
-                # Kiểm tra các cột bắt buộc
                 if not all(col in df.columns for col in required_cols):
                     raise ValueError(f"File Excel (sheet 'Data') phải có các cột bắt buộc: {', '.join(required_cols)}.")
-                
-                # Xóa các thẻ cũ và thêm các thẻ mới từ Excel
-                LearningItem.query.filter_by(container_id=set_id, item_type='FLASHCARD').delete()
-                db.session.flush() # Áp dụng thay đổi xóa trước khi thêm mới
+
+                existing_items = (
+                    LearningItem.query.filter_by(container_id=set_id, item_type='FLASHCARD')
+                    .order_by(LearningItem.order_in_container, LearningItem.item_id)
+                    .all()
+                )
+                existing_map = {item.item_id: item for item in existing_items}
+                processed_ids = set()
+                delete_ids = set()
+                ordered_entries = []
+
+                optional_fields = [
+                    'front_audio_content',
+                    'back_audio_content',
+                    'front_img',
+                    'back_img',
+                    'front_audio_url',
+                    'back_audio_url',
+                    'ai_explanation',
+                    'ai_prompt',
+                ]
+                url_fields = {'front_img', 'back_img', 'front_audio_url', 'back_audio_url'}
+
+                def _get_cell(row_data, column_name):
+                    if column_name not in df.columns:
+                        return None
+                    value = row_data[column_name]
+                    if pd.isna(value):
+                        return None
+                    return str(value).strip()
+
                 for index, row in df.iterrows():
-                    front_content = str(row['front']) if pd.notna(row['front']) else ''
-                    back_content = str(row['back']) if pd.notna(row['back']) else ''
-                    if front_content and back_content:
-                        item_content = {'front': front_content, 'back': back_content}
-                        optional_cols = ['front_audio_content', 'back_audio_content', 'front_img', 'back_img', 'ai_explanation', 'ai_prompt']
-                        for col in optional_cols:
-                            if col in df.columns and pd.notna(row[col]):
-                                item_content[col] = str(row[col])
+                    item_id_value = _get_cell(row, 'item_id')
+                    action_value = (_get_cell(row, 'action') or '').lower()
+                    order_value = _get_cell(row, 'order_in_container')
+                    order_number = None
+                    if order_value:
+                        try:
+                            order_number = int(float(order_value))
+                        except (TypeError, ValueError):
+                            raise ValueError(f"Hàng {index + 2}: order_in_container '{order_value}' không hợp lệ.")
+
+                    front_content = _get_cell(row, 'front') or ''
+                    back_content = _get_cell(row, 'back') or ''
+
+                    item_id = None
+                    if item_id_value:
+                        try:
+                            item_id = int(float(item_id_value))
+                        except (TypeError, ValueError):
+                            raise ValueError(f"Hàng {index + 2}: item_id '{item_id_value}' không hợp lệ.")
+
+                    if item_id:
+                        item = existing_map.get(item_id)
+                        if not item:
+                            raise ValueError(f"Hàng {index + 2}: Không tìm thấy thẻ với ID {item_id}.")
+
+                        if action_value == 'delete':
+                            delete_ids.add(item_id)
+                            continue
+
+                        if not front_content or not back_content:
+                            raise ValueError(f"Hàng {index + 2}: Thẻ với ID {item_id} thiếu dữ liệu front/back.")
+
+                        content_dict = item.content or {}
+                        content_dict['front'] = front_content
+                        content_dict['back'] = back_content
+                        for field in optional_fields:
+                            cell_value = _get_cell(row, field)
+                            if cell_value:
+                                if field in url_fields:
+                                    content_dict[field] = _process_relative_url(cell_value)
+                                else:
+                                    content_dict[field] = cell_value
+                            else:
+                                content_dict.pop(field, None)
+                        item.content = content_dict
+                        flag_modified(item, 'content')
+                        ordered_entries.append({
+                            'type': 'existing',
+                            'item': item,
+                            'order': order_number if order_number is not None else (item.order_in_container or 0),
+                            'sequence': index,
+                        })
+                        processed_ids.add(item_id)
+                    else:
+                        if action_value == 'delete':
+                            continue
+                        if not front_content or not back_content:
+                            # Bỏ qua dòng rỗng
+                            continue
+
+                        content_dict = {'front': front_content, 'back': back_content}
+                        for field in optional_fields:
+                            cell_value = _get_cell(row, field)
+                            if cell_value:
+                                if field in url_fields:
+                                    content_dict[field] = _process_relative_url(cell_value)
+                                else:
+                                    content_dict[field] = cell_value
+                        ordered_entries.append({
+                            'type': 'new',
+                            'data': content_dict,
+                            'order': order_number,
+                            'sequence': index,
+                        })
+
+                untouched_items = [
+                    item for item in existing_items
+                    if item.item_id not in processed_ids and item.item_id not in delete_ids
+                ]
+                for offset, item in enumerate(untouched_items, start=len(df) + 1):
+                    ordered_entries.append({
+                        'type': 'existing',
+                        'item': item,
+                        'order': item.order_in_container or 0,
+                        'sequence': offset,
+                    })
+
+                for delete_id in delete_ids:
+                    if delete_id in existing_map:
+                        db.session.delete(existing_map[delete_id])
+
+                ordered_entries.sort(key=lambda entry: (
+                    entry['order'] if entry['order'] is not None else float('inf'),
+                    entry['sequence'],
+                ))
+
+                next_order = 1
+                for entry in ordered_entries:
+                    if entry['type'] == 'existing':
+                        entry['item'].order_in_container = next_order
+                    else:
                         new_item = LearningItem(
                             container_id=set_id,
                             item_type='FLASHCARD',
-                            content=item_content,
-                            order_in_container=index + 1
+                            content=entry['data'],
+                            order_in_container=next_order,
                         )
                         db.session.add(new_item)
-                flash_message = 'Bộ thẻ và các thẻ từ Excel đã được cập nhật!'
+                    next_order += 1
+
+                flash_message = 'Bộ thẻ và dữ liệu từ Excel đã được cập nhật!'
                 flash_category = 'success'
             else:
                 flash_message = 'Bộ thẻ đã được cập nhật!'

--- a/mindstack_app/modules/content_management/flashcards/templates/_flashcard_sets_list.html
+++ b/mindstack_app/modules/content_management/flashcards/templates/_flashcard_sets_list.html
@@ -44,6 +44,9 @@
                     </a>
                     <div class="flex space-x-3">
                         {% if current_user.user_role == 'admin' or set.creator_user_id == current_user.user_id or (set.contributors and current_user.user_id in set.contributors|map(attribute='user_id')|list and 'editor' in set.contributors|selectattr('user_id', 'equalto', current_user.user_id)|map(attribute='permission_level')|list) %}
+                        <a href="{{ url_for('content_management.content_management_flashcards.export_flashcard_set', set_id=set.container_id) }}" class="text-gray-500 hover:text-purple-600 transition-colors duration-200" title="Xuất bộ thẻ">
+                            <i class="fas fa-file-export"></i>
+                        </a>
                         <button type="button" data-modal-url="{{ url_for('content_management.content_management_flashcards.edit_flashcard_set', set_id=set.container_id) }}" class="open-modal-btn text-gray-500 hover:text-green-600 transition-colors duration-200" title="Sửa">
                             <i class="fas fa-edit"></i>
                         </button>

--- a/mindstack_app/modules/content_management/flashcards/templates/flashcard_items.html
+++ b/mindstack_app/modules/content_management/flashcards/templates/flashcard_items.html
@@ -16,9 +16,14 @@
         </h1>
         
         {% if can_edit %}
-        <a href="{{ url_for('content_management.content_management_flashcards.add_flashcard_item', set_id=flashcard_set.container_id) }}" class="bg-blue-600 text-white px-5 py-2 rounded-md hover:bg-blue-700 transition duration-300 flex items-center">
-            <i class="fas fa-plus-circle mr-2"></i> Thêm thẻ mới
-        </a>
+        <div class="flex items-center gap-3">
+            <a href="{{ url_for('content_management.content_management_flashcards.add_flashcard_item', set_id=flashcard_set.container_id) }}" class="bg-blue-600 text-white px-5 py-2 rounded-md hover:bg-blue-700 transition duration-300 flex items-center">
+                <i class="fas fa-plus-circle mr-2"></i> Thêm thẻ mới
+            </a>
+            <a href="{{ url_for('content_management.content_management_flashcards.export_flashcard_set', set_id=flashcard_set.container_id) }}" class="bg-purple-600 text-white px-4 py-2 rounded-md hover:bg-purple-700 transition duration-300 flex items-center">
+                <i class="fas fa-file-export mr-2"></i> Xuất Excel
+            </a>
+        </div>
         {% endif %}
     </div>
 

--- a/mindstack_app/modules/content_management/quizzes/routes.py
+++ b/mindstack_app/modules/content_management/quizzes/routes.py
@@ -3,7 +3,18 @@
 # MỤC ĐÍCH: Tích hợp quyền chỉnh sửa vào QuizSession.
 # ĐÃ SỬA: Sửa đổi route list_quiz_items để hiển thị đúng nút Sửa.
 
-from flask import Blueprint, render_template, request, redirect, url_for, flash, abort, jsonify, current_app
+from flask import (
+    Blueprint,
+    render_template,
+    request,
+    redirect,
+    url_for,
+    flash,
+    abort,
+    jsonify,
+    current_app,
+    send_file,
+)
 from flask_login import login_required, current_user
 from sqlalchemy import or_
 from sqlalchemy.orm.attributes import flag_modified
@@ -15,6 +26,10 @@ import os
 from ....modules.shared.utils.pagination import get_pagination_data
 from ....modules.shared.utils.search import apply_search_filter
 import copy
+import zipfile
+import shutil
+import re
+import io
 
 quizzes_bp = Blueprint('content_management_quizzes', __name__,
                         template_folder='templates') # Đã cập nhật đường dẫn template
@@ -27,6 +42,16 @@ def _apply_is_public_restrictions(form):
         existing_render_kw = dict(form.is_public.render_kw or {})
         existing_render_kw['disabled'] = True
         form.is_public.render_kw = existing_render_kw
+
+
+def _has_editor_access(container_id):
+    if current_user.user_role == User.ROLE_FREE:
+        return False
+    return ContainerContributor.query.filter_by(
+        container_id=container_id,
+        user_id=current_user.user_id,
+        permission_level='editor'
+    ).first() is not None
 
 def _process_relative_url(url):
     """Chuẩn hóa đường dẫn tương đối và thêm tiền tố tĩnh khi cần."""
@@ -50,6 +75,74 @@ def _build_absolute_media_url(file_path):
     except Exception as exc:
         current_app.logger.error(f"Không thể tạo URL tuyệt đối cho media '{file_path}': {exc}")
         return file_path
+
+
+def _slugify_filename(value: str) -> str:
+    value = (value or '').strip().lower()
+    if not value:
+        return 'quiz-set'
+    value = re.sub(r'[^a-z0-9\-]+', '-', value)
+    value = re.sub(r'-{2,}', '-', value).strip('-')
+    return value or 'quiz-set'
+
+
+def _resolve_local_media_path(path_value: str):
+    if not path_value:
+        return None
+
+    normalized = str(path_value).strip()
+    if not normalized or normalized.startswith(('http://', 'https://')):
+        return None
+
+    base_static = os.path.join(current_app.root_path, 'static')
+    candidates = []
+    if normalized.startswith('/'):
+        candidates.append(os.path.join(base_static, normalized.lstrip('/')))
+    else:
+        upload_folder = current_app.config.get('UPLOAD_FOLDER')
+        if upload_folder:
+            candidates.append(os.path.join(upload_folder, normalized))
+        candidates.append(os.path.join(base_static, normalized))
+
+    for candidate in candidates:
+        if candidate and os.path.isfile(candidate):
+            return candidate
+
+    return None
+
+
+def _copy_media_into_package(original_path: str, media_dir: str, existing_map: dict) -> str:
+    if not original_path:
+        return original_path
+
+    normalized = str(original_path).strip()
+    if not normalized:
+        return ''
+
+    if normalized.startswith(('http://', 'https://')):
+        return normalized
+
+    local_path = _resolve_local_media_path(normalized)
+    if not local_path:
+        return normalized
+
+    if local_path in existing_map:
+        return existing_map[local_path]
+
+    os.makedirs(media_dir, exist_ok=True)
+    filename = os.path.basename(local_path)
+    name, ext = os.path.splitext(filename)
+    candidate = filename
+    counter = 1
+    while os.path.exists(os.path.join(media_dir, candidate)):
+        candidate = f"{name}_{counter}{ext}"
+        counter += 1
+
+    destination = os.path.join(media_dir, candidate)
+    shutil.copy2(local_path, destination)
+    relative_in_zip = os.path.join('media', candidate).replace('\\', '/')
+    existing_map[local_path] = relative_in_zip
+    return relative_in_zip
 
 
 def _serialize_quiz_item_for_response(item, user_id=None):
@@ -169,6 +262,99 @@ def list_quiz_sets():
         return render_template('_quiz_sets_list.html', **template_vars)
     else:
         return render_template('quiz_sets.html', **template_vars)
+
+
+@quizzes_bp.route('/quizzes/<int:set_id>/export', methods=['GET'])
+@login_required
+def export_quiz_set(set_id):
+    """Xuất bộ quiz ra gói zip gồm Excel và media."""
+    quiz_set = LearningContainer.query.get_or_404(set_id)
+
+    if current_user.user_role not in {User.ROLE_ADMIN} and quiz_set.creator_user_id != current_user.user_id:
+        if current_user.user_role == User.ROLE_FREE or not _has_editor_access(set_id):
+            abort(403)
+
+    items = (
+        LearningItem.query.filter_by(container_id=set_id, item_type='QUIZ_MCQ')
+        .order_by(LearningItem.order_in_container, LearningItem.item_id)
+        .all()
+    )
+    groups = {
+        group.group_id: group
+        for group in LearningGroup.query.filter_by(container_id=set_id).all()
+    }
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        media_dir = os.path.join(tmp_dir, 'media')
+        os.makedirs(media_dir, exist_ok=True)
+        media_cache = {}
+
+        info_rows = [
+            {'Key': 'title', 'Value': quiz_set.title},
+            {'Key': 'description', 'Value': quiz_set.description or ''},
+            {'Key': 'tags', 'Value': quiz_set.tags or ''},
+            {'Key': 'is_public', 'Value': str(quiz_set.is_public)},
+        ]
+        if quiz_set.ai_settings:
+            info_rows.append({'Key': 'ai_prompt', 'Value': quiz_set.ai_settings.get('custom_prompt', '')})
+
+        data_rows = []
+        for item in items:
+            content = item.content or {}
+            group = groups.get(item.group_id) if item.group_id else None
+            group_content = group.content if group else {}
+            row = {
+                'item_id': item.item_id,
+                'order_in_container': item.order_in_container,
+                'question': content.get('question'),
+                'pre_question_text': content.get('pre_question_text'),
+                'option_a': (content.get('options') or {}).get('A'),
+                'option_b': (content.get('options') or {}).get('B'),
+                'option_c': (content.get('options') or {}).get('C'),
+                'option_d': (content.get('options') or {}).get('D'),
+                'correct_answer_text': content.get('correct_answer'),
+                'guidance': content.get('explanation'),
+                'question_image_file': _copy_media_into_package(content.get('question_image_file'), media_dir, media_cache),
+                'question_audio_file': _copy_media_into_package(content.get('question_audio_file'), media_dir, media_cache),
+                'passage_text': content.get('passage_text'),
+                'passage_order': content.get('passage_order'),
+                'ai_prompt': content.get('ai_prompt'),
+                'group_id': group.group_id if group else None,
+                'group_ref': f"group-{group.group_id}" if group else '',
+                'group_type': group.group_type if group else '',
+                'group_passage_text': group_content.get('passage_text') if isinstance(group_content, dict) else None,
+                'group_audio_file': _copy_media_into_package(
+                    group_content.get('question_audio_file') if isinstance(group_content, dict) else None,
+                    media_dir,
+                    media_cache,
+                ),
+                'group_image_file': _copy_media_into_package(
+                    group_content.get('question_image_file') if isinstance(group_content, dict) else None,
+                    media_dir,
+                    media_cache,
+                ),
+                'action': '',
+            }
+            data_rows.append(row)
+
+        excel_path = os.path.join(tmp_dir, 'quizzes.xlsx')
+        with pd.ExcelWriter(excel_path, engine='openpyxl') as writer:
+            pd.DataFrame(info_rows).to_excel(writer, sheet_name='Info', index=False)
+            pd.DataFrame(data_rows).to_excel(writer, sheet_name='Data', index=False)
+
+        zip_buffer = io.BytesIO()
+        with zipfile.ZipFile(zip_buffer, 'w', zipfile.ZIP_DEFLATED) as zipf:
+            zipf.write(excel_path, arcname='quizzes.xlsx')
+            if os.path.isdir(media_dir):
+                for root_dir, _, files in os.walk(media_dir):
+                    for filename in files:
+                        file_path = os.path.join(root_dir, filename)
+                        arcname = os.path.relpath(file_path, tmp_dir)
+                        zipf.write(file_path, arcname)
+
+        zip_buffer.seek(0)
+        download_name = f"{_slugify_filename(quiz_set.title)}.zip"
+        return send_file(zip_buffer, as_attachment=True, download_name=download_name, mimetype='application/zip')
 
 @quizzes_bp.route('/quizzes/add', methods=['GET', 'POST'])
 @login_required
@@ -332,13 +518,290 @@ def edit_quiz_set(set_id):
     form = QuizSetForm(obj=quiz_set)
     _apply_is_public_restrictions(form)
     if form.validate_on_submit():
-        quiz_set.title = form.title.data
-        quiz_set.description = form.description.data
-        quiz_set.tags = form.tags.data
-        quiz_set.is_public = False if current_user.user_role == 'free' else form.is_public.data
-        quiz_set.ai_settings = {'custom_prompt': form.ai_prompt.data} if form.ai_prompt.data else None
-        db.session.commit()
-        flash('Bộ câu hỏi đã được cập nhật!', 'success')
+        flash_message = 'Bộ câu hỏi đã được cập nhật!'
+        flash_category = 'success'
+        temp_filepath = None
+        try:
+            quiz_set.title = form.title.data
+            quiz_set.description = form.description.data
+            quiz_set.tags = form.tags.data
+            quiz_set.is_public = False if current_user.user_role == 'free' else form.is_public.data
+            quiz_set.ai_settings = {'custom_prompt': form.ai_prompt.data} if form.ai_prompt.data else None
+
+            if form.excel_file.data and form.excel_file.data.filename != '':
+                excel_file = form.excel_file.data
+                with tempfile.NamedTemporaryFile(delete=False, suffix='.xlsx') as tmp_file:
+                    excel_file.save(tmp_file.name)
+                    temp_filepath = tmp_file.name
+
+                df = pd.read_excel(temp_filepath, sheet_name='Data')
+
+                required_cols = ['option_a', 'option_b', 'correct_answer_text']
+                if not all(col in df.columns for col in required_cols):
+                    raise ValueError(
+                        "File Excel (sheet 'Data') phải có các cột bắt buộc: option_a, option_b, correct_answer_text."
+                    )
+
+                existing_items = (
+                    LearningItem.query.filter_by(container_id=set_id, item_type='QUIZ_MCQ')
+                    .order_by(LearningItem.order_in_container, LearningItem.item_id)
+                    .all()
+                )
+                existing_map = {item.item_id: item for item in existing_items}
+                existing_groups = {
+                    group.group_id: group
+                    for group in LearningGroup.query.filter_by(container_id=set_id).all()
+                }
+
+                processed_ids = set()
+                delete_ids = set()
+                ordered_entries = []
+                group_cache = {}
+
+                def _get_cell(row_data, column_name):
+                    if column_name not in df.columns:
+                        return None
+                    value = row_data[column_name]
+                    if pd.isna(value):
+                        return None
+                    return str(value).strip()
+
+                def _parse_int(value, row_index, field_name):
+                    if value is None or value == '':
+                        return None
+                    try:
+                        return int(float(value))
+                    except (TypeError, ValueError):
+                        raise ValueError(f"Hàng {row_index}: {field_name} '{value}' không hợp lệ.")
+
+                def _resolve_group(row_data, row_index):
+                    group_id_value = _get_cell(row_data, 'group_id')
+                    group_ref_value = _get_cell(row_data, 'group_ref')
+                    group_passage = _get_cell(row_data, 'group_passage_text')
+                    group_audio = _get_cell(row_data, 'group_audio_file')
+                    group_image = _get_cell(row_data, 'group_image_file')
+
+                    group_id_local = None
+                    if group_id_value:
+                        group_id_local = _parse_int(group_id_value, row_index, 'group_id')
+                    elif group_ref_value and group_ref_value.lower().startswith('group-'):
+                        try:
+                            group_id_local = int(group_ref_value.split('-', 1)[1])
+                        except (ValueError, IndexError):
+                            group_id_local = None
+
+                    if group_id_local and group_id_local in existing_groups:
+                        group_obj = existing_groups[group_id_local]
+                        content_dict = dict(group_obj.content or {})
+                        updated = False
+                        if group_passage:
+                            content_dict['passage_text'] = group_passage
+                            updated = True
+                        if group_audio:
+                            content_dict['question_audio_file'] = _process_relative_url(group_audio)
+                            updated = True
+                        if group_image:
+                            content_dict['question_image_file'] = _process_relative_url(group_image)
+                            updated = True
+                        if updated:
+                            group_obj.content = content_dict
+                            flag_modified(group_obj, 'content')
+                        return group_obj
+
+                    if group_ref_value and group_ref_value in group_cache:
+                        return group_cache[group_ref_value]
+
+                    if any([group_passage, group_audio, group_image]):
+                        group_content = {}
+                        if group_passage:
+                            group_content['passage_text'] = group_passage
+                        if group_audio:
+                            group_content['question_audio_file'] = _process_relative_url(group_audio)
+                        if group_image:
+                            group_content['question_image_file'] = _process_relative_url(group_image)
+
+                        if group_passage:
+                            group_type = 'PASSAGE'
+                        elif group_audio:
+                            group_type = 'AUDIO'
+                        elif group_image:
+                            group_type = 'IMAGE'
+                        else:
+                            group_type = 'PASSAGE'
+
+                        new_group = LearningGroup(
+                            container_id=set_id,
+                            group_type=group_type,
+                            content=group_content,
+                        )
+                        db.session.add(new_group)
+                        db.session.flush()
+                        if group_ref_value:
+                            group_cache[group_ref_value] = new_group
+                        return new_group
+
+                    return None
+
+                for index, row in df.iterrows():
+                    row_number = index + 2
+                    item_id_value = _get_cell(row, 'item_id')
+                    action_value = (_get_cell(row, 'action') or '').lower()
+                    order_value = _get_cell(row, 'order_in_container')
+                    order_number = _parse_int(order_value, row_number, 'order_in_container') if order_value else None
+
+                    question_text = _get_cell(row, 'question') or ''
+                    option_a = _get_cell(row, 'option_a')
+                    option_b = _get_cell(row, 'option_b')
+                    option_c = _get_cell(row, 'option_c')
+                    option_d = _get_cell(row, 'option_d')
+                    correct_answer = _get_cell(row, 'correct_answer_text')
+
+                    if not (option_a and option_b and correct_answer) and action_value != 'delete':
+                        raise ValueError(f"Hàng {row_number}: Thiếu option A/B hoặc đáp án đúng.")
+
+                    item_id = None
+                    if item_id_value:
+                        item_id = _parse_int(item_id_value, row_number, 'item_id')
+
+                    if item_id:
+                        item = existing_map.get(item_id)
+                        if not item:
+                            raise ValueError(f"Hàng {row_number}: Không tìm thấy câu hỏi với ID {item_id}.")
+
+                        if action_value == 'delete':
+                            delete_ids.add(item_id)
+                            continue
+
+                        content_dict = item.content or {}
+                        content_dict['question'] = question_text
+                        content_dict.setdefault('options', {})
+                        content_dict['options']['A'] = option_a
+                        content_dict['options']['B'] = option_b
+                        content_dict['options']['C'] = option_c
+                        content_dict['options']['D'] = option_d
+                        content_dict['correct_answer'] = correct_answer
+                        content_dict['explanation'] = _get_cell(row, 'guidance')
+                        content_dict['pre_question_text'] = _get_cell(row, 'pre_question_text')
+                        passage_text = _get_cell(row, 'passage_text')
+                        content_dict['passage_text'] = passage_text
+                        passage_order = _parse_int(_get_cell(row, 'passage_order'), row_number, 'passage_order')
+                        content_dict['passage_order'] = passage_order
+                        image_value = _get_cell(row, 'question_image_file')
+                        audio_value = _get_cell(row, 'question_audio_file')
+                        content_dict['question_image_file'] = _process_relative_url(image_value) if image_value else None
+                        content_dict['question_audio_file'] = _process_relative_url(audio_value) if audio_value else None
+                        ai_prompt_value = _get_cell(row, 'ai_prompt')
+                        if ai_prompt_value:
+                            content_dict['ai_prompt'] = ai_prompt_value
+                        else:
+                            content_dict.pop('ai_prompt', None)
+
+                        item_group = _resolve_group(row, row_number)
+                        item.group_id = item_group.group_id if item_group else None
+
+                        item.content = content_dict
+                        flag_modified(item, 'content')
+
+                        ordered_entries.append({
+                            'type': 'existing',
+                            'item': item,
+                            'order': order_number if order_number is not None else (item.order_in_container or 0),
+                            'sequence': index,
+                        })
+                        processed_ids.add(item_id)
+                    else:
+                        if action_value == 'delete':
+                            continue
+
+                        new_content = {
+                            'question': question_text,
+                            'options': {
+                                'A': option_a,
+                                'B': option_b,
+                                'C': option_c,
+                                'D': option_d,
+                            },
+                            'correct_answer': correct_answer,
+                            'explanation': _get_cell(row, 'guidance'),
+                            'pre_question_text': _get_cell(row, 'pre_question_text'),
+                        }
+                        passage_text = _get_cell(row, 'passage_text')
+                        if passage_text:
+                            new_content['passage_text'] = passage_text
+                        passage_order = _parse_int(_get_cell(row, 'passage_order'), row_number, 'passage_order')
+                        if passage_order is not None:
+                            new_content['passage_order'] = passage_order
+                        image_value = _get_cell(row, 'question_image_file')
+                        audio_value = _get_cell(row, 'question_audio_file')
+                        if image_value:
+                            new_content['question_image_file'] = _process_relative_url(image_value)
+                        if audio_value:
+                            new_content['question_audio_file'] = _process_relative_url(audio_value)
+                        ai_prompt_value = _get_cell(row, 'ai_prompt')
+                        if ai_prompt_value:
+                            new_content['ai_prompt'] = ai_prompt_value
+
+                        item_group = _resolve_group(row, row_number)
+                        ordered_entries.append({
+                            'type': 'new',
+                            'data': new_content,
+                            'group_id': item_group.group_id if item_group else None,
+                            'group_obj': item_group,
+                            'order': order_number,
+                            'sequence': index,
+                        })
+
+                untouched_items = [
+                    item for item in existing_items
+                    if item.item_id not in processed_ids and item.item_id not in delete_ids
+                ]
+                for offset, item in enumerate(untouched_items, start=len(df) + 1):
+                    ordered_entries.append({
+                        'type': 'existing',
+                        'item': item,
+                        'order': item.order_in_container or 0,
+                        'sequence': offset,
+                    })
+
+                for delete_id in delete_ids:
+                    if delete_id in existing_map:
+                        db.session.delete(existing_map[delete_id])
+
+                ordered_entries.sort(key=lambda entry: (
+                    entry['order'] if entry['order'] is not None else float('inf'),
+                    entry['sequence'],
+                ))
+
+                next_order = 1
+                for entry in ordered_entries:
+                    if entry['type'] == 'existing':
+                        entry['item'].order_in_container = next_order
+                    else:
+                        group_id_value = entry.get('group_id')
+                        group_obj = entry.get('group_obj')
+                        new_item = LearningItem(
+                            container_id=set_id,
+                            group_id=group_id_value if group_id_value else (group_obj.group_id if group_obj else None),
+                            item_type='QUIZ_MCQ',
+                            content=entry['data'],
+                            order_in_container=next_order,
+                        )
+                        db.session.add(new_item)
+                    next_order += 1
+
+                flash_message = 'Bộ câu hỏi và dữ liệu từ Excel đã được cập nhật!'
+
+            db.session.commit()
+        except Exception as exc:
+            db.session.rollback()
+            current_app.logger.error(f"Lỗi khi cập nhật bộ quiz: {exc}", exc_info=True)
+            flash_message = f'Lỗi khi xử lý: {exc}'
+            flash_category = 'danger'
+        finally:
+            if temp_filepath and os.path.exists(temp_filepath):
+                os.remove(temp_filepath)
+
+        flash(flash_message, flash_category)
         return redirect(url_for('content_management.content_dashboard', tab='quizzes'))
     
     if request.method == 'GET' and request.args.get('is_modal') == 'true':

--- a/mindstack_app/modules/content_management/quizzes/templates/_quiz_sets_list.html
+++ b/mindstack_app/modules/content_management/quizzes/templates/_quiz_sets_list.html
@@ -44,6 +44,9 @@
                     </a>
                     <div class="flex space-x-3">
                         {% if current_user.user_role == 'admin' or set.creator_user_id == current_user.user_id or (set.contributors and current_user.user_id in set.contributors|map(attribute='user_id')|list and 'editor' in set.contributors|selectattr('user_id', 'equalto', current_user.user_id)|map(attribute='permission_level')|list) %}
+                        <a href="{{ url_for('content_management.content_management_quizzes.export_quiz_set', set_id=set.container_id) }}" class="text-gray-500 hover:text-purple-600 transition-colors duration-200" title="Xuất bộ câu hỏi">
+                            <i class="fas fa-file-export"></i>
+                        </a>
                         <button type="button" data-modal-url="{{ url_for('content_management.content_management_quizzes.edit_quiz_set', set_id=set.container_id) }}" class="open-modal-btn text-gray-500 hover:text-green-600 transition-colors duration-200" title="Sửa">
                             <i class="fas fa-edit"></i>
                         </button>

--- a/mindstack_app/modules/content_management/quizzes/templates/quiz_items.html
+++ b/mindstack_app/modules/content_management/quizzes/templates/quiz_items.html
@@ -21,9 +21,14 @@
         </h1>
         
         {% if can_edit %}
-        <a href="{{ url_for('content_management.content_management_quizzes.add_quiz_item', set_id=quiz_set.container_id) }}" class="bg-blue-600 text-white px-5 py-2 rounded-md hover:bg-blue-700 transition duration-300 flex items-center">
-            <i class="fas fa-plus-circle mr-2"></i> Thêm câu hỏi mới
-        </a>
+        <div class="flex items-center gap-3">
+            <a href="{{ url_for('content_management.content_management_quizzes.add_quiz_item', set_id=quiz_set.container_id) }}" class="bg-blue-600 text-white px-5 py-2 rounded-md hover:bg-blue-700 transition duration-300 flex items-center">
+                <i class="fas fa-plus-circle mr-2"></i> Thêm câu hỏi mới
+            </a>
+            <a href="{{ url_for('content_management.content_management_quizzes.export_quiz_set', set_id=quiz_set.container_id) }}" class="bg-purple-600 text-white px-4 py-2 rounded-md hover:bg-purple-700 transition duration-300 flex items-center">
+                <i class="fas fa-file-export mr-2"></i> Xuất Excel
+            </a>
+        </div>
         {% endif %}
     </div>
 


### PR DESCRIPTION
## Summary
- add reusable helpers and routes to export flashcard and quiz sets as Excel plus bundled media
- expand flashcard and quiz editing flows to reconcile Excel uploads with existing items, including adds, deletes, and reordering
- surface export actions in flashcard and quiz management screens for quick downloads

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7b6bb09c083269c9b1db72855cd42