### PR TITLE
Add Excel management pages and improve media export packaging

### DIFF
--- a/mindstack_app/modules/content_management/flashcards/templates/_flashcard_sets_list.html
+++ b/mindstack_app/modules/content_management/flashcards/templates/_flashcard_sets_list.html
@@ -44,6 +44,12 @@
                     </a>
                     <div class="flex space-x-3">
                         {% if current_user.user_role == 'admin' or set.creator_user_id == current_user.user_id or (set.contributors and current_user.user_id in set.contributors|map(attribute='user_id')|list and 'editor' in set.contributors|selectattr('user_id', 'equalto', current_user.user_id)|map(attribute='permission_level')|list) %}
+                        <a href="{{ url_for('content_management.content_management_flashcards.export_flashcard_set', set_id=set.container_id) }}" class="text-gray-500 hover:text-purple-600 transition-colors duration-200" title="Xuất bộ thẻ">
+                            <i class="fas fa-file-export"></i>
+                        </a>
+                        <a href="{{ url_for('content_management.content_management_flashcards.manage_flashcard_excel', set_id=set.container_id) }}" class="text-gray-500 hover:text-gray-700 transition-colors duration-200" title="Quản lý Excel">
+                            <i class="fas fa-tasks"></i>
+                        </a>
                         <button type="button" data-modal-url="{{ url_for('content_management.content_management_flashcards.edit_flashcard_set', set_id=set.container_id) }}" class="open-modal-btn text-gray-500 hover:text-green-600 transition-colors duration-200" title="Sửa">
                             <i class="fas fa-edit"></i>
                         </button>

--- a/mindstack_app/modules/content_management/flashcards/templates/flashcard_excel_manage.html
+++ b/mindstack_app/modules/content_management/flashcards/templates/flashcard_excel_manage.html
@@ -1,0 +1,54 @@
+{% extends "base.html" %}
+{% block title %}Quản lý Excel cho bộ thẻ: {{ flashcard_set.title }}{% endblock %}
+
+{% block content %}
+<div class="container mx-auto px-4 py-8">
+    <div class="flex items-center justify-between mb-6 flex-wrap gap-4">
+        <h1 class="text-3xl font-semibold text-gray-800">Quản lý Excel cho bộ thẻ: {{ flashcard_set.title }}</h1>
+        <a href="{{ url_for('content_management.content_management_flashcards.list_flashcard_items', set_id=flashcard_set.container_id) }}"
+           class="text-blue-600 hover:text-blue-800 flex items-center">
+            <i class="fas fa-arrow-left mr-2"></i> Quay lại danh sách thẻ
+        </a>
+    </div>
+
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <div class="bg-white shadow-md rounded-lg p-6">
+            <h2 class="text-xl font-semibold text-gray-800 mb-3 flex items-center">
+                <i class="fas fa-file-export text-purple-600 mr-2"></i> Xuất gói dữ liệu hiện tại
+            </h2>
+            <p class="text-gray-600 mb-4">Tải về gói zip bao gồm file Excel và toàn bộ media (audio/hình ảnh) để chỉnh sửa ngoại tuyến.</p>
+            <a href="{{ url_for('content_management.content_management_flashcards.export_flashcard_set', set_id=flashcard_set.container_id) }}"
+               class="inline-flex items-center px-4 py-2 bg-purple-600 text-white rounded-md hover:bg-purple-700 transition">
+                <i class="fas fa-download mr-2"></i> Tải gói Excel + Media
+            </a>
+        </div>
+
+        <div class="bg-white shadow-md rounded-lg p-6">
+            <h2 class="text-xl font-semibold text-gray-800 mb-3 flex items-center">
+                <i class="fas fa-file-import text-green-600 mr-2"></i> Cập nhật từ Excel
+            </h2>
+            <p class="text-gray-600 mb-4">Chọn file Excel (sheet Data) theo định dạng đã xuất. Cột <code>item_id</code> dùng để xác định thẻ hiện có, để trống để tạo mới. Sử dụng cột <code>action</code> với giá trị <strong>Delete</strong> nếu muốn xóa thẻ.</p>
+            <form method="post" enctype="multipart/form-data" class="space-y-4">
+                {{ csrf_token() }}
+                <div>
+                    <label class="block text-sm font-medium text-gray-700 mb-2">Chọn file Excel</label>
+                    <input type="file" name="excel_file" accept=".xlsx" class="w-full border border-gray-300 rounded-md px-3 py-2" required>
+                </div>
+                <button type="submit" class="inline-flex items-center px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 transition">
+                    <i class="fas fa-upload mr-2"></i> Tải lên và cập nhật
+                </button>
+            </form>
+        </div>
+    </div>
+
+    <div class="mt-8 bg-blue-50 border border-blue-100 rounded-lg p-6">
+        <h3 class="text-lg font-semibold text-blue-800 mb-3">Hướng dẫn nhanh</h3>
+        <ul class="list-disc list-inside text-blue-900 space-y-2">
+            <li>Giữ nguyên sheet <strong>Info</strong> để hệ thống bảo toàn thông tin bộ thẻ.</li>
+            <li>Mỗi hàng trong sheet <strong>Data</strong> tương ứng với một thẻ. Điền <code>item_id</code> khi muốn cập nhật, để trống để thêm thẻ mới.</li>
+            <li>Thiết lập <code>order_in_container</code> nếu muốn điều chỉnh thứ tự, hoặc để trống để thêm vào cuối danh sách.</li>
+            <li>Các file audio sẽ được ánh xạ lại vào thư mục <code>media/audio</code> và hình ảnh vào <code>media/images</code> trong gói xuất.</li>
+        </ul>
+    </div>
+</div>
+{% endblock %}

--- a/mindstack_app/modules/content_management/flashcards/templates/flashcard_items.html
+++ b/mindstack_app/modules/content_management/flashcards/templates/flashcard_items.html
@@ -16,9 +16,17 @@
         </h1>
         
         {% if can_edit %}
-        <a href="{{ url_for('content_management.content_management_flashcards.add_flashcard_item', set_id=flashcard_set.container_id) }}" class="bg-blue-600 text-white px-5 py-2 rounded-md hover:bg-blue-700 transition duration-300 flex items-center">
-            <i class="fas fa-plus-circle mr-2"></i> Thêm thẻ mới
-        </a>
+        <div class="flex items-center gap-3">
+            <a href="{{ url_for('content_management.content_management_flashcards.add_flashcard_item', set_id=flashcard_set.container_id) }}" class="bg-blue-600 text-white px-5 py-2 rounded-md hover:bg-blue-700 transition duration-300 flex items-center">
+                <i class="fas fa-plus-circle mr-2"></i> Thêm thẻ mới
+            </a>
+            <a href="{{ url_for('content_management.content_management_flashcards.export_flashcard_set', set_id=flashcard_set.container_id) }}" class="bg-purple-600 text-white px-4 py-2 rounded-md hover:bg-purple-700 transition duration-300 flex items-center">
+                <i class="fas fa-file-export mr-2"></i> Xuất Excel
+            </a>
+            <a href="{{ url_for('content_management.content_management_flashcards.manage_flashcard_excel', set_id=flashcard_set.container_id) }}" class="bg-gray-200 text-gray-800 px-4 py-2 rounded-md hover:bg-gray-300 transition duration-300 flex items-center">
+                <i class="fas fa-tasks mr-2"></i> Quản lý Excel
+            </a>
+        </div>
         {% endif %}
     </div>
 

--- a/mindstack_app/modules/content_management/quizzes/templates/_quiz_sets_list.html
+++ b/mindstack_app/modules/content_management/quizzes/templates/_quiz_sets_list.html
@@ -44,6 +44,12 @@
                     </a>
                     <div class="flex space-x-3">
                         {% if current_user.user_role == 'admin' or set.creator_user_id == current_user.user_id or (set.contributors and current_user.user_id in set.contributors|map(attribute='user_id')|list and 'editor' in set.contributors|selectattr('user_id', 'equalto', current_user.user_id)|map(attribute='permission_level')|list) %}
+                        <a href="{{ url_for('content_management.content_management_quizzes.export_quiz_set', set_id=set.container_id) }}" class="text-gray-500 hover:text-purple-600 transition-colors duration-200" title="Xuất bộ câu hỏi">
+                            <i class="fas fa-file-export"></i>
+                        </a>
+                        <a href="{{ url_for('content_management.content_management_quizzes.manage_quiz_excel', set_id=set.container_id) }}" class="text-gray-500 hover:text-gray-700 transition-colors duration-200" title="Quản lý Excel">
+                            <i class="fas fa-tasks"></i>
+                        </a>
                         <button type="button" data-modal-url="{{ url_for('content_management.content_management_quizzes.edit_quiz_set', set_id=set.container_id) }}" class="open-modal-btn text-gray-500 hover:text-green-600 transition-colors duration-200" title="Sửa">
                             <i class="fas fa-edit"></i>
                         </button>

--- a/mindstack_app/modules/content_management/quizzes/templates/quiz_excel_manage.html
+++ b/mindstack_app/modules/content_management/quizzes/templates/quiz_excel_manage.html
@@ -1,0 +1,54 @@
+{% extends "base.html" %}
+{% block title %}Quản lý Excel cho bộ câu hỏi: {{ quiz_set.title }}{% endblock %}
+
+{% block content %}
+<div class="container mx-auto px-4 py-8">
+    <div class="flex items-center justify-between mb-6 flex-wrap gap-4">
+        <h1 class="text-3xl font-semibold text-gray-800">Quản lý Excel cho bộ câu hỏi: {{ quiz_set.title }}</h1>
+        <a href="{{ url_for('content_management.content_management_quizzes.list_quiz_items', set_id=quiz_set.container_id) }}"
+           class="text-blue-600 hover:text-blue-800 flex items-center">
+            <i class="fas fa-arrow-left mr-2"></i> Quay lại danh sách câu hỏi
+        </a>
+    </div>
+
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <div class="bg-white shadow-md rounded-lg p-6">
+            <h2 class="text-xl font-semibold text-gray-800 mb-3 flex items-center">
+                <i class="fas fa-file-export text-purple-600 mr-2"></i> Xuất gói dữ liệu hiện tại
+            </h2>
+            <p class="text-gray-600 mb-4">Gói zip bao gồm file Excel và media (audio/hình ảnh) của toàn bộ câu hỏi.</p>
+            <a href="{{ url_for('content_management.content_management_quizzes.export_quiz_set', set_id=quiz_set.container_id) }}"
+               class="inline-flex items-center px-4 py-2 bg-purple-600 text-white rounded-md hover:bg-purple-700 transition">
+                <i class="fas fa-download mr-2"></i> Tải gói Excel + Media
+            </a>
+        </div>
+
+        <div class="bg-white shadow-md rounded-lg p-6">
+            <h2 class="text-xl font-semibold text-gray-800 mb-3 flex items-center">
+                <i class="fas fa-file-import text-green-600 mr-2"></i> Cập nhật từ Excel
+            </h2>
+            <p class="text-gray-600 mb-4">Điền <code>item_id</code> cho câu hỏi cần cập nhật, để trống để tạo mới. Cột <code>action</code> nhận giá trị <strong>Delete</strong> để xóa câu hỏi.</p>
+            <form method="post" enctype="multipart/form-data" class="space-y-4">
+                {{ csrf_token() }}
+                <div>
+                    <label class="block text-sm font-medium text-gray-700 mb-2">Chọn file Excel</label>
+                    <input type="file" name="excel_file" accept=".xlsx" class="w-full border border-gray-300 rounded-md px-3 py-2" required>
+                </div>
+                <button type="submit" class="inline-flex items-center px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 transition">
+                    <i class="fas fa-upload mr-2"></i> Tải lên và cập nhật
+                </button>
+            </form>
+        </div>
+    </div>
+
+    <div class="mt-8 bg-blue-50 border border-blue-100 rounded-lg p-6">
+        <h3 class="text-lg font-semibold text-blue-800 mb-3">Hướng dẫn nhanh</h3>
+        <ul class="list-disc list-inside text-blue-900 space-y-2">
+            <li>Giữ nguyên sheet <strong>Info</strong> để bảo toàn thông tin bộ câu hỏi.</li>
+            <li>Các nhóm (passage/audio/hình) được nhận diện qua cột <code>group_id</code> hoặc <code>group_ref</code>. Điền các cột <code>group_passage_text</code>, <code>group_audio_file</code>, <code>group_image_file</code> để cập nhật nội dung nhóm.</li>
+            <li>Ảnh và audio được tái ánh xạ vào thư mục <code>media/images</code> và <code>media/audio</code> khi xuất.</li>
+            <li><code>order_in_container</code> xác định vị trí câu hỏi, để trống nếu muốn chèn cuối danh sách.</li>
+        </ul>
+    </div>
+</div>
+{% endblock %}

--- a/mindstack_app/modules/content_management/quizzes/templates/quiz_items.html
+++ b/mindstack_app/modules/content_management/quizzes/templates/quiz_items.html
@@ -21,9 +21,17 @@
         </h1>
         
         {% if can_edit %}
-        <a href="{{ url_for('content_management.content_management_quizzes.add_quiz_item', set_id=quiz_set.container_id) }}" class="bg-blue-600 text-white px-5 py-2 rounded-md hover:bg-blue-700 transition duration-300 flex items-center">
-            <i class="fas fa-plus-circle mr-2"></i> Thêm câu hỏi mới
-        </a>
+        <div class="flex items-center gap-3">
+            <a href="{{ url_for('content_management.content_management_quizzes.add_quiz_item', set_id=quiz_set.container_id) }}" class="bg-blue-600 text-white px-5 py-2 rounded-md hover:bg-blue-700 transition duration-300 flex items-center">
+                <i class="fas fa-plus-circle mr-2"></i> Thêm câu hỏi mới
+            </a>
+            <a href="{{ url_for('content_management.content_management_quizzes.export_quiz_set', set_id=quiz_set.container_id) }}" class="bg-purple-600 text-white px-4 py-2 rounded-md hover:bg-purple-700 transition duration-300 flex items-center">
+                <i class="fas fa-file-export mr-2"></i> Xuất Excel
+            </a>
+            <a href="{{ url_for('content_management.content_management_quizzes.manage_quiz_excel', set_id=quiz_set.container_id) }}" class="bg-gray-200 text-gray-800 px-4 py-2 rounded-md hover:bg-gray-300 transition duration-300 flex items-center">
+                <i class="fas fa-tasks mr-2"></i> Quản lý Excel
+            </a>
+        </div>
         {% endif %}
     </div>
 


### PR DESCRIPTION
## Summary
- update flashcard and quiz export helpers to separate audio and image assets into media/audio and media/images
- add reusable Excel reconciliation helpers plus standalone management pages for flashcard and quiz editors
- surface quick links to the new Excel management pages alongside existing export actions in list and item views

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7b6bb09c083269c9b1db72855cd42