### PR TITLE
Add flashcard capability modes and form flags

### DIFF
--- a/mindstack_app/modules/content_management/flashcards/routes.py
+++ b/mindstack_app/modules/content_management/flashcards/routes.py
@@ -953,6 +953,9 @@ def add_flashcard_item(set_id):
             'back_audio_url': _process_relative_url(form.back_audio_url.data),
             'front_img': _process_relative_url(form.front_img.data),
             'back_img': _process_relative_url(form.back_img.data),
+            'supports_pronunciation': bool(form.supports_pronunciation.data),
+            'supports_writing': bool(form.supports_writing.data),
+            'supports_quiz': bool(form.supports_quiz.data),
         }
         if form.ai_prompt.data:
             content_dict['ai_prompt'] = form.ai_prompt.data
@@ -1054,6 +1057,9 @@ def edit_flashcard_item(set_id, item_id):
         flashcard_item.content['back_audio_url'] = _process_relative_url(form.back_audio_url.data)
         flashcard_item.content['front_img'] = _process_relative_url(form.front_img.data)
         flashcard_item.content['back_img'] = _process_relative_url(form.back_img.data)
+        flashcard_item.content['supports_pronunciation'] = bool(form.supports_pronunciation.data)
+        flashcard_item.content['supports_writing'] = bool(form.supports_writing.data)
+        flashcard_item.content['supports_quiz'] = bool(form.supports_quiz.data)
         
         if form.ai_prompt.data:
             flashcard_item.content['ai_prompt'] = form.ai_prompt.data
@@ -1086,6 +1092,9 @@ def edit_flashcard_item(set_id, item_id):
         form.front_img.data = flashcard_item.content.get('front_img')
         form.back_img.data = flashcard_item.content.get('back_img')
         form.ai_prompt.data = flashcard_item.content.get('ai_prompt')
+        form.supports_pronunciation.data = bool(flashcard_item.content.get('supports_pronunciation'))
+        form.supports_writing.data = bool(flashcard_item.content.get('supports_writing'))
+        form.supports_quiz.data = bool(flashcard_item.content.get('supports_quiz'))
         # Gán giá trị `order_in_container` vào form
         form.order_in_container.data = flashcard_item.order_in_container
     

--- a/mindstack_app/modules/content_management/flashcards/templates/_add_edit_flashcard_item_bare.html
+++ b/mindstack_app/modules/content_management/flashcards/templates/_add_edit_flashcard_item_bare.html
@@ -209,23 +209,53 @@
                                 </div>
                             </div>
                         </div>
-                        <div>
-                            {{ form.ai_prompt.label(class="block text-sm font-medium text-gray-700") }}
-                            <p class="text-xs text-gray-500 mb-2">{{ form.ai_prompt.description }}</p>
-                            {{ form.ai_prompt(class="mt-1 block w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500", rows="3", placeholder="Nhập prompt tùy chỉnh...") }}
-                        </div>
-                        <div>
-                            <div class="flex items-center justify-between">
-                                {{ form.ai_explanation.label(class="block text-sm font-medium text-gray-700") }}
-                                {% if flashcard_item and (current_user.user_role == 'admin' or flashcard_item.container.creator_user_id == current_user.user_id) %}
-                                <button type="button" id="ai-regenerate-btn" class="text-sm text-blue-600 hover:text-blue-800 transition-colors duration-200">
-                                    <i class="fas fa-sync-alt mr-1"></i> Tái tạo lại
-                                </button>
-                                {% endif %}
-                            </div>
-                            {{ form.ai_explanation(class="mt-1 block w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm bg-gray-50 focus:outline-none", rows="3", readonly=True) }}
-                        </div>
                     </div>
+                </div>
+
+                <div class="border-t border-gray-200 pt-6">
+                    <h3 class="text-lg font-semibold text-gray-800 mb-4">Kiểu học hỗ trợ</h3>
+                    <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+                        <label class="flex items-start gap-3 p-4 bg-gray-50 border border-gray-200 rounded-lg">
+                            {{ form.supports_pronunciation(class="mt-1 h-5 w-5 text-blue-600") }}
+                            <span>
+                                <span class="block text-sm font-medium text-gray-800">Luyện phát âm</span>
+                                <span class="block text-xs text-gray-500 mt-1">Thẻ có âm thanh hoặc nội dung phù hợp để luyện nghe - nói.</span>
+                            </span>
+                        </label>
+                        <label class="flex items-start gap-3 p-4 bg-gray-50 border border-gray-200 rounded-lg">
+                            {{ form.supports_writing(class="mt-1 h-5 w-5 text-blue-600") }}
+                            <span>
+                                <span class="block text-sm font-medium text-gray-800">Luyện viết</span>
+                                <span class="block text-xs text-gray-500 mt-1">Thẻ có thể dùng để luyện viết chính tả hoặc mô tả lại.</span>
+                            </span>
+                        </label>
+                        <label class="flex items-start gap-3 p-4 bg-gray-50 border border-gray-200 rounded-lg">
+                            {{ form.supports_quiz(class="mt-1 h-5 w-5 text-blue-600") }}
+                            <span>
+                                <span class="block text-sm font-medium text-gray-800">Luyện trắc nghiệm</span>
+                                <span class="block text-xs text-gray-500 mt-1">Thẻ phù hợp để chuyển thành câu hỏi dạng lựa chọn.</span>
+                            </span>
+                        </label>
+                    </div>
+                    <p class="text-xs text-gray-500 mt-3">Đánh dấu các kiểu học mà thẻ này hỗ trợ để mở thêm chế độ tương ứng trong khi học.</p>
+                </div>
+
+                <div class="border-t border-gray-200 pt-6">
+                    {{ form.ai_prompt.label(class="block text-sm font-medium text-gray-700") }}
+                    <p class="text-xs text-gray-500 mb-2">{{ form.ai_prompt.description }}</p>
+                    {{ form.ai_prompt(class="mt-1 block w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500", rows="3", placeholder="Nhập prompt tùy chỉnh...") }}
+                </div>
+
+                <div class="border-t border-gray-200 pt-6">
+                    <div class="flex items-center justify-between">
+                        {{ form.ai_explanation.label(class="block text-sm font-medium text-gray-700") }}
+                        {% if flashcard_item and (current_user.user_role == 'admin' or flashcard_item.container.creator_user_id == current_user.user_id) %}
+                        <button type="button" id="ai-regenerate-btn" class="text-sm text-blue-600 hover:text-blue-800 transition-colors duration-200">
+                            <i class="fas fa-sync-alt mr-1"></i> Tái tạo lại
+                        </button>
+                        {% endif %}
+                    </div>
+                    {{ form.ai_explanation(class="mt-1 block w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm bg-gray-50 focus:outline-none", rows="3", readonly=True) }}
                 </div>
 
                 <div class="flex justify-end space-x-4 pt-4">

--- a/mindstack_app/modules/content_management/flashcards/templates/add_edit_flashcard_item.html
+++ b/mindstack_app/modules/content_management/flashcards/templates/add_edit_flashcard_item.html
@@ -212,6 +212,34 @@
                 </div>
 
                 <div class="border-t border-gray-200 pt-6">
+                    <h3 class="text-lg font-semibold text-gray-800 mb-4">Kiểu học hỗ trợ</h3>
+                    <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+                        <label class="flex items-start gap-3 p-4 bg-gray-50 border border-gray-200 rounded-lg">
+                            {{ form.supports_pronunciation(class="mt-1 h-5 w-5 text-blue-600") }}
+                            <span>
+                                <span class="block text-sm font-medium text-gray-800">Luyện phát âm</span>
+                                <span class="block text-xs text-gray-500 mt-1">Thẻ có âm thanh hoặc nội dung phù hợp để luyện nghe - nói.</span>
+                            </span>
+                        </label>
+                        <label class="flex items-start gap-3 p-4 bg-gray-50 border border-gray-200 rounded-lg">
+                            {{ form.supports_writing(class="mt-1 h-5 w-5 text-blue-600") }}
+                            <span>
+                                <span class="block text-sm font-medium text-gray-800">Luyện viết</span>
+                                <span class="block text-xs text-gray-500 mt-1">Thẻ có thể dùng để luyện viết chính tả hoặc mô tả lại.</span>
+                            </span>
+                        </label>
+                        <label class="flex items-start gap-3 p-4 bg-gray-50 border border-gray-200 rounded-lg">
+                            {{ form.supports_quiz(class="mt-1 h-5 w-5 text-blue-600") }}
+                            <span>
+                                <span class="block text-sm font-medium text-gray-800">Luyện trắc nghiệm</span>
+                                <span class="block text-xs text-gray-500 mt-1">Thẻ phù hợp để chuyển thành câu hỏi dạng lựa chọn.</span>
+                            </span>
+                        </label>
+                    </div>
+                    <p class="text-xs text-gray-500 mt-3">Đánh dấu các kiểu học mà thẻ này hỗ trợ để mở thêm chế độ tương ứng trong khi học.</p>
+                </div>
+
+                <div class="border-t border-gray-200 pt-6">
                     {{ form.ai_prompt.label(class="block text-sm font-medium text-gray-700") }}
                     <p class="text-xs text-gray-500 mb-2">{{ form.ai_prompt.description }}</p>
                     {{ form.ai_prompt(class="mt-1 block w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500", rows="3", placeholder="Nhập prompt tùy chỉnh...") }}

--- a/mindstack_app/modules/content_management/forms.py
+++ b/mindstack_app/modules/content_management/forms.py
@@ -108,9 +108,12 @@ class FlashcardItemForm(FlaskForm):
     front_img = StringField('URL hình ảnh mặt trước', validators=[Optional()])
     back_img = StringField('URL hình ảnh mặt sau', validators=[Optional()])
     ai_explanation = TextAreaField('Giải thích AI', render_kw={'readonly': True}, validators=[Optional()])
-    ai_prompt = TextAreaField('AI Prompt tùy chỉnh (cho thẻ này)', 
+    ai_prompt = TextAreaField('AI Prompt tùy chỉnh (cho thẻ này)',
                               description='Nhập prompt tùy chỉnh để ghi đè prompt của bộ thẻ hoặc mặc định hệ thống. Nếu để trống, hệ thống sẽ tự động sử dụng prompt cấp trên.',
                               validators=[Optional()])
+    supports_pronunciation = BooleanField('Hỗ trợ luyện phát âm')
+    supports_writing = BooleanField('Hỗ trợ luyện viết')
+    supports_quiz = BooleanField('Hỗ trợ luyện trắc nghiệm')
     order_in_container = IntegerField('Thứ tự hiển thị', validators=[
         Optional(),
         NumberRange(min=1, message="Thứ tự phải là một số nguyên dương.")

--- a/mindstack_app/modules/learning/flashcard_learning/config.py
+++ b/mindstack_app/modules/learning/flashcard_learning/config.py
@@ -18,4 +18,25 @@ class FlashcardLearningConfig:
         {'id': 'due_only', 'name': 'Ôn tập thẻ đến hạn', 'algorithm_func_name': 'get_due_items'},
         {'id': 'all_review', 'name': 'Ôn tập toàn bộ thẻ đã học', 'algorithm_func_name': 'get_all_review_items'},
         {'id': 'hard_only', 'name': 'Ôn tập thẻ khó', 'algorithm_func_name': 'get_hard_items'},
+        {
+            'id': 'pronunciation_practice',
+            'name': 'Luyện phát âm',
+            'algorithm_func_name': 'get_pronunciation_items',
+            'capability_flag': 'supports_pronunciation',
+            'hide_if_zero': True,
+        },
+        {
+            'id': 'writing_practice',
+            'name': 'Luyện viết',
+            'algorithm_func_name': 'get_writing_items',
+            'capability_flag': 'supports_writing',
+            'hide_if_zero': True,
+        },
+        {
+            'id': 'quiz_practice',
+            'name': 'Luyện trắc nghiệm',
+            'algorithm_func_name': 'get_quiz_items',
+            'capability_flag': 'supports_quiz',
+            'hide_if_zero': True,
+        },
     ]

--- a/mindstack_app/modules/learning/flashcard_learning/session_manager.py
+++ b/mindstack_app/modules/learning/flashcard_learning/session_manager.py
@@ -14,6 +14,9 @@ from .algorithms import (
     get_all_review_items,
     get_all_items_for_autoplay,
     get_accessible_flashcard_set_ids,
+    get_pronunciation_items,
+    get_writing_items,
+    get_quiz_items,
 )
 from .flashcard_logic import process_flashcard_answer
 from .flashcard_stats_logic import get_flashcard_item_statistics
@@ -91,6 +94,9 @@ class FlashcardSessionManager:
             'hard_only': get_hard_items,
             'mixed_srs': get_mixed_items,
             'all_review': get_all_review_items,
+            'pronunciation_practice': get_pronunciation_items,
+            'writing_practice': get_writing_items,
+            'quiz_practice': get_quiz_items,
             'autoplay_all': get_all_items_for_autoplay,
             'autoplay_learned': get_all_review_items,
         }.get(mode)
@@ -201,6 +207,21 @@ class FlashcardSessionManager:
                 get_all_items_for_autoplay(self.user_id, self.set_id, None)
             ).order_by(LearningItem.order_in_container.asc(), LearningItem.item_id.asc())
             next_item = query.first()
+        elif self.mode == 'pronunciation_practice':
+            query = apply_exclusion(
+                get_pronunciation_items(self.user_id, self.set_id, None)
+            ).order_by(LearningItem.order_in_container.asc(), LearningItem.item_id.asc())
+            next_item = query.first()
+        elif self.mode == 'writing_practice':
+            query = apply_exclusion(
+                get_writing_items(self.user_id, self.set_id, None)
+            ).order_by(LearningItem.order_in_container.asc(), LearningItem.item_id.asc())
+            next_item = query.first()
+        elif self.mode == 'quiz_practice':
+            query = apply_exclusion(
+                get_quiz_items(self.user_id, self.set_id, None)
+            ).order_by(LearningItem.order_in_container.asc(), LearningItem.item_id.asc())
+            next_item = query.first()
         else:
             due_query = apply_exclusion(
                 get_due_items(self.user_id, self.set_id, None)
@@ -230,6 +251,9 @@ class FlashcardSessionManager:
                 'back_audio_url': self._get_media_absolute_url(next_item.content.get('back_audio_url')),
                 'front_img': self._get_media_absolute_url(next_item.content.get('front_img')),
                 'back_img': self._get_media_absolute_url(next_item.content.get('back_img')),
+                'supports_pronunciation': bool(next_item.content.get('supports_pronunciation')),
+                'supports_writing': bool(next_item.content.get('supports_writing')),
+                'supports_quiz': bool(next_item.content.get('supports_quiz')),
             },
             'ai_explanation': next_item.ai_explanation,
             'initial_stats': initial_stats  # Gửi kèm thống kê


### PR DESCRIPTION
## Summary
- add metadata flags to flashcards with UI checkboxes for pronunciation, writing, and quiz practice
- surface capability-specific flashcard modes and filtering logic when counts are available
- expose capability flags in session payloads so the learner UI can react to the selected mode

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7dca7a4888326bdfb48314f728e57