### PR TITLE
Group flashcard mode selection by learning category

### DIFF
--- a/mindstack_app/modules/learning/flashcard_learning/templates/_flashcard_modes_selection.html
+++ b/mindstack_app/modules/learning/flashcard_learning/templates/_flashcard_modes_selection.html
@@ -3,97 +3,157 @@
 {# Mục đích: Partial template chứa cả các chế độ học, tùy chọn số nút đánh giá và cấu hình AutoPlay. #}
 {# ĐÃ CẬP NHẬT: Bổ sung chế độ AutoPlay với tùy chọn phạm vi và tốc độ. #}
 
-{% set autoplay_mode = namespace(data=None) %}
-{% for mode in modes %}
-    {% if mode.id == 'autoplay' %}
-        {% set autoplay_mode.data = mode %}
-    {% endif %}
-{% endfor %}
+{% if mode_groups is defined and mode_groups %}
+    {% set groups = mode_groups %}
+{% else %}
+    {% set groups = [{
+        'id': 'flashcard',
+        'icon': 'fas fa-layer-group',
+        'title': 'Chế độ Flashcard',
+        'description': 'Chọn chế độ ôn tập phù hợp với tiến độ học tập của bạn.',
+        'modes': modes
+    }] %}
+{% endif %}
 
-<div class="w-full space-y-3">
-    {# Dropdown chọn số nút đánh giá #}
-    <div id="button-count-container" class="mb-4 p-4 bg-white rounded-lg border border-gray-200">
-        <label for="button-count-select" class="block text-sm font-medium text-gray-700 mb-2">Số nút đánh giá:</label>
-        <select id="button-count-select" class="block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm">
-            <option value="3" {% if user_button_count == 3 %}selected{% endif %}>3 nút (MindStack: Quên, Mơ hồ, Nhớ)</option>
-            <option value="4" {% if user_button_count == 4 %}selected{% endif %}>4 nút (Anki: Again, Hard, Good, Easy)</option>
-            <option value="6" {% if user_button_count == 6 %}selected{% endif %}>6 nút (Full SM-2: Rất khó -> Rất dễ)</option>
-        </select>
-    </div>
-
-    {# Tùy chọn cho chế độ AutoPlay (ẩn mặc định, hiển thị khi người dùng chọn) #}
-    <div id="autoplay-settings-container" class="mb-4 p-4 bg-white rounded-lg border border-blue-200 hidden">
-        {% set autoplay_counts = autoplay_mode.data.autoplay_counts if autoplay_mode.data and autoplay_mode.data.autoplay_counts is defined else {} %}
-        {% set autoplay_learned_count = autoplay_counts.autoplay_learned | default(0) %}
-        {% set autoplay_all_count = autoplay_counts.autoplay_all | default(0) %}
-        <div class="flex items-center justify-between mb-3">
-            <h3 class="text-base font-semibold text-gray-800 flex items-center"><i class="fas fa-headphones mr-2 text-blue-500"></i>Tuỳ chọn AutoPlay</h3>
-            <span class="text-xs text-gray-500">Âm thanh sẽ phát tự động trước khi lật thẻ.</span>
-        </div>
-        <div class="space-y-3">
-            <div>
-                <p class="text-sm font-medium text-gray-700 mb-2">Phạm vi AutoPlay:</p>
-                <div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
-                    <label class="autoplay-scope-option flex items-center p-3 border border-gray-200 rounded-lg cursor-pointer hover:border-blue-400 transition">
-                        <input type="radio" name="autoplay-scope" value="autoplay_learned" class="mr-3" data-count="{{ autoplay_learned_count }}">
-                        <span class="text-sm text-gray-700">Chỉ thẻ đã học <span class="text-xs text-gray-500">({{ autoplay_learned_count }} thẻ)</span></span>
-                    </label>
-                    <label class="autoplay-scope-option flex items-center p-3 border border-gray-200 rounded-lg cursor-pointer hover:border-blue-400 transition">
-                        <input type="radio" name="autoplay-scope" value="autoplay_all" class="mr-3" data-count="{{ autoplay_all_count }}">
-                        <span class="text-sm text-gray-700">Toàn bộ thẻ <span class="text-xs text-gray-500">({{ autoplay_all_count }} thẻ)</span></span>
-                    </label>
-                </div>
-            </div>
-            <div>
-                <label for="autoplay-delay-select" class="block text-sm font-medium text-gray-700 mb-2">Thời gian chờ sau mỗi mặt thẻ (giây):</label>
-                <select id="autoplay-delay-select" class="block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm">
-                    <option value="1">1 giây</option>
-                    <option value="2">2 giây</option>
-                    <option value="3">3 giây</option>
-                    <option value="5">5 giây</option>
-                </select>
-            </div>
-        </div>
-    </div>
-
-    {# Danh sách các chế độ học #}
-    <div class="space-y-3">
-    {% if modes %}
-        {% for mode in modes %}
-            {% set is_disabled_mode = (mode.count == 0) %}
-            {% if mode.id == 'autoplay' %}
-                {% set autoplay_counts = mode.autoplay_counts if mode.autoplay_counts is defined else {} %}
-                {% set autoplay_learned_count = autoplay_counts.autoplay_learned | default(0) %}
-                {% set autoplay_all_count = autoplay_counts.autoplay_all | default(0) %}
-                {% set has_available_autoplay = autoplay_learned_count > 0 or autoplay_all_count > 0 %}
-                <div class="flashcard-mode-item bg-white p-4 rounded-lg border border-gray-200 transition-colors duration-200
-                            {% if not has_available_autoplay %}opacity-50 cursor-not-allowed{% else %}cursor-pointer hover:bg-gray-100{% endif %}"
-                     data-mode-id="autoplay"
-                     data-count="{{ mode.count }}"
-                     data-autoplay-learned="{{ autoplay_learned_count }}"
-                     data-autoplay-all="{{ autoplay_all_count }}"
-                     {% if not has_available_autoplay %}title="Không có thẻ phù hợp cho AutoPlay."{% endif %}>
+<div class="w-full space-y-6">
+    {% if groups %}
+        {% for group in groups %}
+            {% set group_icon = group.icon if group.icon is defined and group.icon else 'fas fa-layer-group' %}
+            {% set group_title = group.title if group.title is defined else 'Nhóm chế độ học' %}
+            {% set group_description = group.description if group.description is defined else '' %}
+            {% set group_modes = group.modes if group.modes is defined else [] %}
+            <div class="rounded-xl border border-gray-200 bg-white/70 p-5 shadow-sm">
+                <div class="flex items-start">
+                    <div class="mr-3 flex h-10 w-10 items-center justify-center rounded-full bg-blue-50 text-lg text-blue-500">
+                        <i class="{{ group_icon }}"></i>
+                    </div>
                     <div>
-                        <h3 class="font-semibold text-gray-800 flex items-center"><i class="fas fa-music mr-2 text-blue-500"></i>{{ mode.name }}</h3>
-                        <p class="text-sm text-gray-500 mt-1">Lắng nghe và lật thẻ tự động theo tốc độ bạn chọn.</p>
-                    </div>
-                    <div class="text-right text-sm text-gray-600">
-                        <div><span class="font-semibold text-gray-700">{{ autoplay_learned_count }}</span> đã học</div>
-                        <div><span class="font-semibold text-gray-700">{{ autoplay_all_count }}</span> tổng thẻ</div>
+                        <h2 class="text-lg font-semibold text-gray-800">{{ group_title }}</h2>
+                        {% if group_description %}
+                            <p class="mt-1 text-sm text-gray-500">{{ group_description }}</p>
+                        {% endif %}
                     </div>
                 </div>
-            {% else %}
-                <div class="flashcard-mode-item bg-white p-4 rounded-lg border border-gray-200 transition-colors duration-200 flex justify-between items-center
-                            {% if is_disabled_mode %}opacity-50 cursor-not-allowed{% else %}cursor-pointer hover:bg-gray-100{% endif %}"
-                     data-mode-id="{{ mode.id }}"
-                     data-count="{{ mode.count }}"
-                     {% if is_disabled_mode %}title="Chế độ này không có thẻ nào khả dụng."{% endif %}>
-                    <h3 class="font-semibold text-gray-800">{{ mode.name }}</h3>
-                    <div class="flex items-center">
-                        <span class="text-lg font-semibold text-gray-700">{{ mode.count }}</span>
-                    </div>
+
+                <div class="mt-5 space-y-4">
+                    {% if group.id == 'flashcard' %}
+                        {% set autoplay_mode = namespace(data=None) %}
+                        {% for mode in group_modes %}
+                            {% if mode.id == 'autoplay' %}
+                                {% set autoplay_mode.data = mode %}
+                            {% endif %}
+                        {% endfor %}
+
+                        <div id="button-count-container" class="p-4 bg-white rounded-lg border border-gray-200">
+                            <label for="button-count-select" class="block text-sm font-medium text-gray-700 mb-2">Số nút đánh giá:</label>
+                            <select id="button-count-select" class="block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm">
+                                <option value="3" {% if user_button_count == 3 %}selected{% endif %}>3 nút (MindStack: Quên, Mơ hồ, Nhớ)</option>
+                                <option value="4" {% if user_button_count == 4 %}selected{% endif %}>4 nút (Anki: Again, Hard, Good, Easy)</option>
+                                <option value="6" {% if user_button_count == 6 %}selected{% endif %}>6 nút (Full SM-2: Rất khó -> Rất dễ)</option>
+                            </select>
+                        </div>
+
+                        {% set autoplay_counts = autoplay_mode.data.autoplay_counts if autoplay_mode.data and autoplay_mode.data.autoplay_counts is defined else {} %}
+                        {% set autoplay_learned_count = autoplay_counts.autoplay_learned | default(0) %}
+                        {% set autoplay_all_count = autoplay_counts.autoplay_all | default(0) %}
+
+                        <div id="autoplay-settings-container" class="hidden p-4 bg-white rounded-lg border border-blue-200">
+                            <div class="flex items-center justify-between mb-3">
+                                <h3 class="text-base font-semibold text-gray-800 flex items-center"><i class="fas fa-headphones mr-2 text-blue-500"></i>Tuỳ chọn AutoPlay</h3>
+                                <span class="text-xs text-gray-500">Âm thanh sẽ phát tự động trước khi lật thẻ.</span>
+                            </div>
+                            <div class="space-y-3">
+                                <div>
+                                    <p class="text-sm font-medium text-gray-700 mb-2">Phạm vi AutoPlay:</p>
+                                    <div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                                        <label class="autoplay-scope-option flex items-center p-3 border border-gray-200 rounded-lg cursor-pointer hover:border-blue-400 transition">
+                                            <input type="radio" name="autoplay-scope" value="autoplay_learned" class="mr-3" data-count="{{ autoplay_learned_count }}">
+                                            <span class="text-sm text-gray-700">Chỉ thẻ đã học <span class="text-xs text-gray-500">({{ autoplay_learned_count }} thẻ)</span></span>
+                                        </label>
+                                        <label class="autoplay-scope-option flex items-center p-3 border border-gray-200 rounded-lg cursor-pointer hover:border-blue-400 transition">
+                                            <input type="radio" name="autoplay-scope" value="autoplay_all" class="mr-3" data-count="{{ autoplay_all_count }}">
+                                            <span class="text-sm text-gray-700">Toàn bộ thẻ <span class="text-xs text-gray-500">({{ autoplay_all_count }} thẻ)</span></span>
+                                        </label>
+                                    </div>
+                                </div>
+                                <div>
+                                    <label for="autoplay-delay-select" class="block text-sm font-medium text-gray-700 mb-2">Thời gian chờ sau mỗi mặt thẻ (giây):</label>
+                                    <select id="autoplay-delay-select" class="block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm">
+                                        <option value="1">1 giây</option>
+                                        <option value="2">2 giây</option>
+                                        <option value="3">3 giây</option>
+                                        <option value="5">5 giây</option>
+                                    </select>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="space-y-3">
+                            {% if group_modes %}
+                                {% for mode in group_modes %}
+                                    {% set is_disabled_mode = (mode.count == 0) %}
+                                    {% if mode.id == 'autoplay' %}
+                                        {% set autoplay_counts = mode.autoplay_counts if mode.autoplay_counts is defined else {} %}
+                                        {% set autoplay_learned_count = autoplay_counts.autoplay_learned | default(0) %}
+                                        {% set autoplay_all_count = autoplay_counts.autoplay_all | default(0) %}
+                                        {% set has_available_autoplay = autoplay_learned_count > 0 or autoplay_all_count > 0 %}
+                                        <div class="flashcard-mode-item bg-white p-4 rounded-lg border border-gray-200 transition-colors duration-200 {% if not has_available_autoplay %}opacity-50 cursor-not-allowed{% else %}cursor-pointer hover:bg-gray-100{% endif %}"
+                                             data-mode-id="autoplay"
+                                             data-count="{{ mode.count }}"
+                                             data-autoplay-learned="{{ autoplay_learned_count }}"
+                                             data-autoplay-all="{{ autoplay_all_count }}"
+                                             {% if not has_available_autoplay %}title="Không có thẻ phù hợp cho AutoPlay."{% endif %}>
+                                            <div>
+                                                <h3 class="font-semibold text-gray-800 flex items-center"><i class="fas fa-music mr-2 text-blue-500"></i>{{ mode.name }}</h3>
+                                                <p class="text-sm text-gray-500 mt-1">Lắng nghe và lật thẻ tự động theo tốc độ bạn chọn.</p>
+                                            </div>
+                                            <div class="text-right text-sm text-gray-600">
+                                                <div><span class="font-semibold text-gray-700">{{ autoplay_learned_count }}</span> đã học</div>
+                                                <div><span class="font-semibold text-gray-700">{{ autoplay_all_count }}</span> tổng thẻ</div>
+                                            </div>
+                                        </div>
+                                    {% else %}
+                                        <div class="flashcard-mode-item bg-white p-4 rounded-lg border border-gray-200 transition-colors duration-200 flex justify-between items-center {% if is_disabled_mode %}opacity-50 cursor-not-allowed{% else %}cursor-pointer hover:bg-gray-100{% endif %}"
+                                             data-mode-id="{{ mode.id }}"
+                                             data-count="{{ mode.count }}"
+                                             {% if is_disabled_mode %}title="Chế độ này không có thẻ nào khả dụng."{% endif %}>
+                                            <h3 class="font-semibold text-gray-800">{{ mode.name }}</h3>
+                                            <div class="flex items-center">
+                                                <span class="text-lg font-semibold text-gray-700">{{ mode.count }}</span>
+                                            </div>
+                                        </div>
+                                    {% endif %}
+                                {% endfor %}
+                            {% else %}
+                                <div class="text-center py-12 px-6 text-gray-600">
+                                    <i class="fas fa-info-circle text-5xl text-gray-300 mb-4"></i>
+                                    <p>Không có chế độ học nào khả dụng.</p>
+                                </div>
+                            {% endif %}
+                        </div>
+                    {% else %}
+                        <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                            {% if group_modes %}
+                                {% for mode in group_modes %}
+                                    <div class="relative flex flex-col justify-between rounded-lg border border-dashed border-gray-300 bg-gray-50 p-4 text-gray-500 shadow-inner">
+                                        <div class="mb-3 flex items-center text-sm font-semibold text-gray-600">
+                                            <i class="fas fa-tools mr-2 text-gray-400"></i>
+                                            {{ mode.name or 'Tính năng đang phát triển' }}
+                                        </div>
+                                        <p class="text-xs leading-5 text-gray-500">{{ mode.description if mode.description is defined else 'Tính năng đang phát triển. Vui lòng quay lại sau!' }}</p>
+                                        <div class="pointer-events-none absolute inset-0 rounded-lg bg-white opacity-0"></div>
+                                    </div>
+                                {% endfor %}
+                            {% else %}
+                                <div class="rounded-lg border border-dashed border-gray-300 bg-gray-50 p-6 text-center text-sm text-gray-500">
+                                    <i class="fas fa-hammer text-xl text-gray-400 mb-2"></i>
+                                    <p>Tính năng đang phát triển. Vui lòng quay lại sau!</p>
+                                </div>
+                            {% endif %}
+                        </div>
+                    {% endif %}
                 </div>
-            {% endif %}
+            </div>
         {% endfor %}
     {% else %}
         <div class="text-center py-12 px-6 text-gray-600">
@@ -101,5 +161,4 @@
             <p>Không có chế độ học nào khả dụng.</p>
         </div>
     {% endif %}
-    </div>
 </div>


### PR DESCRIPTION
## Summary
- restructure the flashcard modes partial to iterate over group metadata and render per-group headers
- move the button-count selector and autoplay controls into the flashcard group while preserving mode data attributes
- surface placeholder cards for listening, speaking, quiz, and writing groups to preview upcoming modes

## Testing
- not run (HTML-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d7ec1fe0cc83268cfd70d5b23ac18c