### PR TITLE
Organize flashcard modes into grouped metadata for dashboard

### DIFF
--- a/mindstack_app/modules/learning/flashcard_learning/config.py
+++ b/mindstack_app/modules/learning/flashcard_learning/config.py
@@ -7,36 +7,137 @@ class FlashcardLearningConfig:
     """
     Cấu hình cho module học Flashcard.
     """
-    DEFAULT_ITEMS_PER_PAGE = 12 # Số mục mặc định trên mỗi trang cho Flashcard
+
+    DEFAULT_ITEMS_PER_PAGE = 12  # Số mục mặc định trên mỗi trang cho Flashcard
     AUTOPLAY_MODE_NAME = 'Chế độ AutoPlay'
 
-    # Định nghĩa các chế độ học Flashcard
-    # THAY ĐỔI: Thêm chế độ học "Học và ôn tập" lên đầu danh sách
-    FLASHCARD_MODES = [
-        {'id': 'mixed_srs', 'name': 'Học tập tuần tự', 'algorithm_func_name': 'get_mixed_items'},
-        {'id': 'new_only', 'name': 'Chỉ học thẻ mới', 'algorithm_func_name': 'get_new_only_items'},
-        {'id': 'due_only', 'name': 'Ôn tập thẻ đến hạn', 'algorithm_func_name': 'get_due_items'},
-        {'id': 'all_review', 'name': 'Ôn tập toàn bộ thẻ đã học', 'algorithm_func_name': 'get_all_review_items'},
-        {'id': 'hard_only', 'name': 'Ôn tập thẻ khó', 'algorithm_func_name': 'get_hard_items'},
+    # Định nghĩa các nhóm chế độ học Flashcard để giao diện có thể hiển thị theo cụm.
+    # Mỗi nhóm bao gồm metadata hiển thị (icon, mô tả) và danh sách chế độ con.
+    FLASHCARD_MODE_GROUPS = [
         {
-            'id': 'pronunciation_practice',
-            'name': 'Luyện phát âm',
-            'algorithm_func_name': 'get_pronunciation_items',
-            'capability_flag': 'supports_pronunciation',
-            'hide_if_zero': True,
+            'id': 'flashcard',
+            'title': 'Ôn tập thẻ',
+            'description': 'Các chế độ học truyền thống và AutoPlay giúp bạn xoay vòng thẻ linh hoạt.',
+            'icon': 'fas fa-layer-group',
+            'modes': [
+                {
+                    'id': 'mixed_srs',
+                    'name': 'Học tập tuần tự',
+                    'description': 'Kết hợp thẻ mới và thẻ đến hạn theo thuật toán SRS.',
+                    'algorithm_func_name': 'get_mixed_items',
+                },
+                {
+                    'id': 'new_only',
+                    'name': 'Chỉ học thẻ mới',
+                    'description': 'Tập trung vào những thẻ bạn chưa từng xem.',
+                    'algorithm_func_name': 'get_new_only_items',
+                },
+                {
+                    'id': 'due_only',
+                    'name': 'Ôn tập thẻ đến hạn',
+                    'description': 'Ôn những thẻ đến hạn theo lịch SRS.',
+                    'algorithm_func_name': 'get_due_items',
+                },
+                {
+                    'id': 'all_review',
+                    'name': 'Ôn tập toàn bộ thẻ đã học',
+                    'description': 'Làm mới toàn bộ kiến thức với những thẻ đã có tiến độ.',
+                    'algorithm_func_name': 'get_all_review_items',
+                },
+                {
+                    'id': 'hard_only',
+                    'name': 'Ôn tập thẻ khó',
+                    'description': 'Rèn luyện chuyên sâu với các thẻ bạn thường đánh giá là khó.',
+                    'algorithm_func_name': 'get_hard_items',
+                },
+                {
+                    'id': 'autoplay',
+                    'name': AUTOPLAY_MODE_NAME,
+                    'description': 'Nghe phát lại mặt trước và sau của thẻ hoàn toàn tự động.',
+                    'is_autoplay': True,
+                },
+            ],
         },
         {
-            'id': 'writing_practice',
-            'name': 'Luyện viết',
-            'algorithm_func_name': 'get_writing_items',
-            'capability_flag': 'supports_writing',
-            'hide_if_zero': True,
+            'id': 'listening',
+            'title': 'Luyện nghe',
+            'description': 'Các hoạt động luyện nghe chuyên sâu sẽ được ra mắt sớm.',
+            'icon': 'fas fa-headphones',
+            'modes': [],
+            'is_placeholder': True,
+            'placeholder_copy': 'Chúng tôi đang xây dựng các chế độ luyện nghe mới. Hãy quay lại sau!',
         },
         {
-            'id': 'quiz_practice',
-            'name': 'Luyện trắc nghiệm',
-            'algorithm_func_name': 'get_quiz_items',
-            'capability_flag': 'supports_quiz',
-            'hide_if_zero': True,
+            'id': 'speaking',
+            'title': 'Luyện nói',
+            'description': 'Ghi âm và so sánh phát âm để cải thiện khả năng nói.',
+            'icon': 'fas fa-microphone-alt',
+            'modes': [
+                {
+                    'id': 'pronunciation_practice',
+                    'name': 'Luyện phát âm',
+                    'description': 'Nghe mẫu và luyện nói theo từng thẻ.',
+                    'algorithm_func_name': 'get_pronunciation_items',
+                    'capability_flag': 'supports_pronunciation',
+                    'hide_if_zero': True,
+                },
+            ],
+        },
+        {
+            'id': 'quiz',
+            'title': 'Trắc nghiệm',
+            'description': 'Kiểm tra nhanh với các câu hỏi trắc nghiệm.',
+            'icon': 'fas fa-question-circle',
+            'modes': [
+                {
+                    'id': 'quiz_practice',
+                    'name': 'Luyện trắc nghiệm',
+                    'description': 'Chọn đáp án đúng để kiểm tra khả năng ghi nhớ.',
+                    'algorithm_func_name': 'get_quiz_items',
+                    'capability_flag': 'supports_quiz',
+                    'hide_if_zero': True,
+                },
+            ],
+        },
+        {
+            'id': 'writing',
+            'title': 'Luyện viết',
+            'description': 'Ghi nhớ bằng cách viết lại đáp án hoặc chữ cái.',
+            'icon': 'fas fa-pen-fancy',
+            'modes': [
+                {
+                    'id': 'writing_practice',
+                    'name': 'Luyện viết',
+                    'description': 'Luyện viết lại đáp án của thẻ.',
+                    'algorithm_func_name': 'get_writing_items',
+                    'capability_flag': 'supports_writing',
+                    'hide_if_zero': True,
+                },
+            ],
         },
     ]
+
+    # Tra cứu nhanh metadata của từng chế độ theo ID và danh sách phẳng phục vụ các logic cũ.
+    _mode_map = {}
+    _flat_modes = []
+    for _group in FLASHCARD_MODE_GROUPS:
+        for _mode in _group.get('modes', []):
+            mode_id = _mode['id']
+            mode_metadata = {
+                **_mode,
+                'group_id': _group['id'],
+                'group_title': _group.get('title'),
+                'group_icon': _group.get('icon'),
+                'group_description': _group.get('description'),
+                'group_placeholder_copy': _group.get('placeholder_copy'),
+                'group_is_placeholder': _group.get('is_placeholder', False),
+            }
+            _mode_map[mode_id] = mode_metadata
+            if not mode_metadata.get('is_autoplay'):
+                _flat_modes.append(mode_metadata)
+
+    FLASHCARD_MODE_MAP = _mode_map
+    FLASHCARD_MODES = _flat_modes
+
+    del _mode_map
+    del _flat_modes

--- a/mindstack_app/modules/learning/flashcard_learning/routes.py
+++ b/mindstack_app/modules/learning/flashcard_learning/routes.py
@@ -101,18 +101,18 @@ def get_flashcard_options_partial(set_identifier):
     selected_mode = request.args.get('selected_mode', None, type=str)
     user_button_count = current_user.flashcard_button_count if current_user.flashcard_button_count else 3
     
-    modes = []
-    
+    mode_groups = []
+
     if set_identifier == 'all':
-        modes = get_flashcard_mode_counts(current_user.user_id, 'all')
+        mode_groups = get_flashcard_mode_counts(current_user.user_id, 'all')
     else:
         try:
             set_ids = [int(s) for s in set_identifier.split(',') if s]
             if len(set_ids) == 1:
                 # THAY ĐỔI: Lấy phần tử đầu tiên của danh sách
-                modes = get_flashcard_mode_counts(current_user.user_id, set_ids[0])
+                mode_groups = get_flashcard_mode_counts(current_user.user_id, set_ids[0])
             else:
-                modes = get_flashcard_mode_counts(current_user.user_id, set_ids)
+                mode_groups = get_flashcard_mode_counts(current_user.user_id, set_ids)
         except ValueError:
             return '<p class="text-red-500 text-center">Lỗi: Định dạng ID bộ thẻ không hợp lệ.</p>', 400
         except IndexError:
@@ -120,7 +120,7 @@ def get_flashcard_options_partial(set_identifier):
 
 
     return render_template('_flashcard_modes_selection.html',
-                           modes=modes,
+                           mode_groups=mode_groups,
                            selected_set_id=set_identifier,
                            selected_flashcard_mode_id=selected_mode,
                            user_button_count=user_button_count

--- a/mindstack_app/modules/learning/flashcard_learning/templates/_flashcard_modes_selection.html
+++ b/mindstack_app/modules/learning/flashcard_learning/templates/_flashcard_modes_selection.html
@@ -4,10 +4,12 @@
 {# ĐÃ CẬP NHẬT: Bổ sung chế độ AutoPlay với tùy chọn phạm vi và tốc độ. #}
 
 {% set autoplay_mode = namespace(data=None) %}
-{% for mode in modes %}
-    {% if mode.id == 'autoplay' %}
-        {% set autoplay_mode.data = mode %}
-    {% endif %}
+{% for group in mode_groups %}
+    {% for mode in group.modes %}
+        {% if mode.id == 'autoplay' %}
+            {% set autoplay_mode.data = mode %}
+        {% endif %}
+    {% endfor %}
 {% endfor %}
 
 <div class="w-full space-y-3">
@@ -57,43 +59,81 @@
     </div>
 
     {# Danh sách các chế độ học #}
-    <div class="space-y-3">
-    {% if modes %}
-        {% for mode in modes %}
-            {% set is_disabled_mode = (mode.count == 0) %}
-            {% if mode.id == 'autoplay' %}
-                {% set autoplay_counts = mode.autoplay_counts if mode.autoplay_counts is defined else {} %}
-                {% set autoplay_learned_count = autoplay_counts.autoplay_learned | default(0) %}
-                {% set autoplay_all_count = autoplay_counts.autoplay_all | default(0) %}
-                {% set has_available_autoplay = autoplay_learned_count > 0 or autoplay_all_count > 0 %}
-                <div class="flashcard-mode-item bg-white p-4 rounded-lg border border-gray-200 transition-colors duration-200
-                            {% if not has_available_autoplay %}opacity-50 cursor-not-allowed{% else %}cursor-pointer hover:bg-gray-100{% endif %}"
-                     data-mode-id="autoplay"
-                     data-count="{{ mode.count }}"
-                     data-autoplay-learned="{{ autoplay_learned_count }}"
-                     data-autoplay-all="{{ autoplay_all_count }}"
-                     {% if not has_available_autoplay %}title="Không có thẻ phù hợp cho AutoPlay."{% endif %}>
-                    <div>
-                        <h3 class="font-semibold text-gray-800 flex items-center"><i class="fas fa-music mr-2 text-blue-500"></i>{{ mode.name }}</h3>
-                        <p class="text-sm text-gray-500 mt-1">Lắng nghe và lật thẻ tự động theo tốc độ bạn chọn.</p>
+    <div class="space-y-6">
+    {% if mode_groups %}
+        {% for group in mode_groups %}
+            <div class="space-y-3">
+                <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+                    <div class="flex items-start space-x-3">
+                        {% if group.icon %}
+                            <span class="text-blue-500 text-xl sm:text-2xl"><i class="{{ group.icon }}"></i></span>
+                        {% endif %}
+                        <div>
+                            <h2 class="text-lg font-semibold text-gray-800">{{ group.title }}</h2>
+                            {% if group.description %}
+                                <p class="text-sm text-gray-500">{{ group.description }}</p>
+                            {% endif %}
+                        </div>
                     </div>
-                    <div class="text-right text-sm text-gray-600">
-                        <div><span class="font-semibold text-gray-700">{{ autoplay_learned_count }}</span> đã học</div>
-                        <div><span class="font-semibold text-gray-700">{{ autoplay_all_count }}</span> tổng thẻ</div>
-                    </div>
+                    {% if group.total_modes is not none and group.configured_modes > 0 %}
+                        <span class="text-xs font-medium text-gray-500 uppercase tracking-wide">{{ group.active_modes }}/{{ group.total_modes }} chế độ khả dụng</span>
+                    {% endif %}
                 </div>
-            {% else %}
-                <div class="flashcard-mode-item bg-white p-4 rounded-lg border border-gray-200 transition-colors duration-200 flex justify-between items-center
-                            {% if is_disabled_mode %}opacity-50 cursor-not-allowed{% else %}cursor-pointer hover:bg-gray-100{% endif %}"
-                     data-mode-id="{{ mode.id }}"
-                     data-count="{{ mode.count }}"
-                     {% if is_disabled_mode %}title="Chế độ này không có thẻ nào khả dụng."{% endif %}>
-                    <h3 class="font-semibold text-gray-800">{{ mode.name }}</h3>
-                    <div class="flex items-center">
-                        <span class="text-lg font-semibold text-gray-700">{{ mode.count }}</span>
+
+                {% if group.modes %}
+                    <div class="space-y-2">
+                        {% for mode in group.modes %}
+                            {% set is_disabled_mode = (mode.count == 0) %}
+                            {% if mode.is_autoplay %}
+                                {% set autoplay_counts = mode.autoplay_counts if mode.autoplay_counts is defined else {} %}
+                                {% set autoplay_learned_count = autoplay_counts.autoplay_learned | default(0) %}
+                                {% set autoplay_all_count = autoplay_counts.autoplay_all | default(0) %}
+                                {% set has_available_autoplay = autoplay_learned_count > 0 or autoplay_all_count > 0 %}
+                                <div class="flashcard-mode-item bg-white p-4 rounded-lg border border-gray-200 transition-colors duration-200
+                                            {% if not has_available_autoplay %}opacity-50 cursor-not-allowed{% else %}cursor-pointer hover:bg-gray-100{% endif %}"
+                                     data-mode-id="autoplay"
+                                     data-count="{{ mode.count }}"
+                                     data-autoplay-learned="{{ autoplay_learned_count }}"
+                                     data-autoplay-all="{{ autoplay_all_count }}"
+                                     {% if not has_available_autoplay %}title="Không có thẻ phù hợp cho AutoPlay."{% endif %}>
+                                    <div>
+                                        <h3 class="font-semibold text-gray-800 flex items-center"><i class="fas fa-music mr-2 text-blue-500"></i>{{ mode.name }}</h3>
+                                        <p class="text-sm text-gray-500 mt-1">{{ mode.description or 'Lắng nghe và lật thẻ tự động theo tốc độ bạn chọn.' }}</p>
+                                    </div>
+                                    <div class="text-right text-sm text-gray-600">
+                                        <div><span class="font-semibold text-gray-700">{{ autoplay_learned_count }}</span> đã học</div>
+                                        <div><span class="font-semibold text-gray-700">{{ autoplay_all_count }}</span> tổng thẻ</div>
+                                    </div>
+                                </div>
+                            {% else %}
+                                <div class="flashcard-mode-item bg-white p-4 rounded-lg border border-gray-200 transition-colors duration-200 flex justify-between items-center
+                                            {% if is_disabled_mode %}opacity-50 cursor-not-allowed{% else %}cursor-pointer hover:bg-gray-100{% endif %}"
+                                     data-mode-id="{{ mode.id }}"
+                                     data-count="{{ mode.count }}"
+                                     {% if is_disabled_mode %}title="Chế độ này không có thẻ nào khả dụng."{% endif %}>
+                                    <div>
+                                        <h3 class="font-semibold text-gray-800">{{ mode.name }}</h3>
+                                        {% if mode.description %}
+                                            <p class="text-xs text-gray-500 mt-1">{{ mode.description }}</p>
+                                        {% endif %}
+                                    </div>
+                                    <div class="flex items-center">
+                                        <span class="text-lg font-semibold text-gray-700">{{ mode.count }}</span>
+                                    </div>
+                                </div>
+                            {% endif %}
+                        {% endfor %}
                     </div>
-                </div>
-            {% endif %}
+                {% elif group.is_placeholder %}
+                    <div class="p-4 border-2 border-dashed border-gray-300 rounded-lg bg-gray-50 text-sm text-gray-600">
+                        {{ group.placeholder_copy or 'Chúng tôi đang xây dựng các chế độ học mới cho nhóm này.' }}
+                    </div>
+                {% else %}
+                    <div class="p-4 border border-gray-200 rounded-lg text-sm text-gray-600">
+                        Không có chế độ học nào khả dụng trong nhóm này.
+                    </div>
+                {% endif %}
+            </div>
         {% endfor %}
     {% else %}
         <div class="text-center py-12 px-6 text-gray-600">


### PR DESCRIPTION
## Summary
- organize flashcard learning configuration into top-level mode groups with icons, descriptions, and a lookup map for resolving mode metadata
- refactor flashcard mode counting to build grouped payloads, including Autoplay handling and capability-aware filtering
- update the options partial to consume grouped mode data and present grouped sections in the template

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7ec191edc8326ad6d56c98cec724a