### PR TITLE
Use usernames for contributor management

### DIFF
--- a/mindstack_app/modules/content_management/flashcards/routes.py
+++ b/mindstack_app/modules/content_management/flashcards/routes.py
@@ -566,10 +566,7 @@ def list_flashcard_sets():
         # Thông tin người tạo
         creator = getattr(set_item, 'creator', None)
         if creator:
-            creator_label = creator.username
-            if creator.user_id == current_user.user_id:
-                creator_label += " (Bạn)"
-            set_item.creator_display_name = creator_label
+            set_item.creator_display_name = creator.username
         else:
             set_item.creator_display_name = "Không xác định"
 
@@ -579,12 +576,7 @@ def list_flashcard_sets():
 
         if creator:
             seen_user_ids.add(creator.user_id)
-            creator_editor_label = creator.username
-            if creator.user_id == current_user.user_id:
-                creator_editor_label += " (Bạn)"
-            else:
-                creator_editor_label += " (Người tạo)"
-            editor_labels.append(creator_editor_label)
+            editor_labels.append(creator.username)
 
         for contributor in getattr(set_item, 'contributors', []) or []:
             if contributor.permission_level != 'editor':
@@ -593,10 +585,7 @@ def list_flashcard_sets():
             if not contributor_user or contributor_user.user_id in seen_user_ids:
                 continue
 
-            contributor_label = contributor_user.username
-            if contributor_user.user_id == current_user.user_id:
-                contributor_label += " (Bạn)"
-            editor_labels.append(contributor_label)
+            editor_labels.append(contributor_user.username)
             seen_user_ids.add(contributor_user.user_id)
 
         if not editor_labels:

--- a/mindstack_app/modules/content_management/forms.py
+++ b/mindstack_app/modules/content_management/forms.py
@@ -5,7 +5,7 @@
 
 from flask_wtf import FlaskForm
 from wtforms import StringField, TextAreaField, BooleanField, SubmitField, FileField, SelectField, IntegerField
-from wtforms.validators import DataRequired, Length, Optional, ValidationError, Email, NumberRange
+from wtforms.validators import DataRequired, Length, Optional, ValidationError, NumberRange
 from flask_wtf.file import FileAllowed
 import re
 
@@ -15,11 +15,12 @@ import re
 
 class ContributorForm(FlaskForm):
     """
-    Form để thêm một người đóng góp mới bằng email.
+    Form để thêm một người đóng góp mới bằng tên người dùng.
     """
-    email = StringField('Email của người dùng', 
-                        validators=[DataRequired(message="Vui lòng nhập email."), 
-                                    Email(message="Địa chỉ email không hợp lệ.")])
+    username = StringField('Tên người dùng',
+                           validators=[DataRequired(message="Vui lòng nhập tên người dùng."),
+                                       Length(max=150, message="Tên người dùng tối đa 150 ký tự.")],
+                           render_kw={'autocomplete': 'off'})
     permission_level = SelectField('Cấp độ quyền', 
                                    choices=[('editor', 'Editor (Chỉnh sửa)')], # Hiện tại chỉ có 1 cấp độ
                                    validators=[DataRequired()])

--- a/mindstack_app/modules/content_management/templates/manage_contributors.html
+++ b/mindstack_app/modules/content_management/templates/manage_contributors.html
@@ -25,11 +25,16 @@
                 <form method="POST" action="{{ url_for('content_management.manage_contributors', container_id=container.container_id) }}">
                     {{ form.hidden_tag() }}
                     <div class="mb-4">
-                        <label for="{{ form.email.id }}" class="block text-sm font-medium text-gray-700">{{ form.email.label }}</label>
-                        {{ form.email(class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm") }}
-                        {% if form.email.errors %}
+                        <label for="{{ form.username.id }}" class="block text-sm font-medium text-gray-700">{{ form.username.label }}</label>
+                        {{ form.username(class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm", list="username-suggestions") }}
+                        <datalist id="username-suggestions">
+                            {% for username in username_suggestions %}
+                                <option value="{{ username }}"></option>
+                            {% endfor %}
+                        </datalist>
+                        {% if form.username.errors %}
                             <ul class="text-red-500 text-xs mt-1">
-                            {% for error in form.email.errors %}
+                            {% for error in form.username.errors %}
                                 <li>{{ error }}</li>
                             {% endfor %}
                             </ul>


### PR DESCRIPTION
## Summary
- remove the "(Bạn)" and "(Người tạo)" suffixes when showing flashcard creators and editors
- switch contributor management to accept usernames instead of email addresses and provide username suggestions

## Testing
- pytest tests -q

------
https://chatgpt.com/codex/tasks/task_e_68d7fb84901c8326b88c33048d25976a