### PR TITLE
Restore flashcard session layout balance

### DIFF
--- a/mindstack_app/modules/learning/flashcard_learning/templates/_flashcard_session_stats.html
+++ b/mindstack_app/modules/learning/flashcard_learning/templates/_flashcard_session_stats.html
@@ -10,17 +10,23 @@
         border: 1px solid rgba(148, 163, 184, 0.2);
         border-radius: 16px;
         box-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
-        padding: 1.25rem 1.5rem;
+        padding: 1.5rem 1.75rem;
         display: flex;
         flex-direction: column;
         gap: 1rem;
         color: #0f172a;
-        max-width: 520px;
         width: 100%;
-        overflow-y: auto;
+        max-width: 100%;
         max-height: 100%;
+        overflow: visible;
         scrollbar-width: thin;
         scrollbar-color: rgba(148, 163, 184, 0.35) transparent;
+    }
+
+    .stats-stack {
+        display: flex;
+        flex-direction: column;
+        gap: 1.25rem;
     }
 
     .sr-only {
@@ -242,8 +248,8 @@
     }
 
     .stats-section + .stats-section {
-        margin-top: 1.1rem;
-        padding-top: 1.1rem;
+        margin-top: 0;
+        padding-top: 0;
     }
 
     .stats-section__header {
@@ -729,6 +735,41 @@
     .statistics-card--modal {
         max-height: none;
         overflow: visible;
+    }
+
+    @media (max-width: 1024px) {
+        .statistics-card {
+            overflow-y: auto;
+            padding: 1.25rem 1.5rem;
+        }
+    }
+
+    @media (min-width: 1280px) {
+        .statistics-card {
+            padding: 1.75rem 2rem;
+        }
+        .stats-stack {
+            display: grid;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: 1.5rem;
+            align-content: start;
+        }
+        .stats-stack > .insight-banner,
+        .stats-stack > .stats-section--recent,
+        .stats-stack > .stats-section--timeline {
+            grid-column: 1 / -1;
+        }
+        .session-overview {
+            flex-wrap: wrap;
+            overflow: visible;
+            gap: 1rem;
+        }
+        .session-overview > * {
+            min-width: 240px;
+        }
+        .stats-tab-nav {
+            overflow: visible;
+        }
     }
 
     @media (min-width: 1024px) {

--- a/mindstack_app/modules/learning/flashcard_learning/templates/flashcard_session.html
+++ b/mindstack_app/modules/learning/flashcard_learning/templates/flashcard_session.html
@@ -79,7 +79,7 @@
     .session-layout {
         height: 100%;
         display: grid;
-        grid-template-columns: minmax(0, 5fr) minmax(400px, 2fr);
+        grid-template-columns: minmax(0, 2fr) minmax(0, 3fr);
         gap: 2rem;
         max-width: 1680px;
         margin: 0 auto;
@@ -88,8 +88,6 @@
         min-height: 0;
         flex-grow: 1;
         box-sizing: border-box;
-        /* THAY ĐỔI: Cố định layout */
-        overflow: hidden;
     }
 
     @media (max-width: 1024px) {
@@ -119,6 +117,7 @@
             overflow: hidden;
             display: flex;
             flex-direction: column;
+            max-width: none;
         }
         #flashcard-content {
             flex: 1;
@@ -151,6 +150,9 @@
         .flashcard-card {
             padding: 0.2rem !important;
         }
+        .flashcard-card-container {
+            max-width: none;
+        }
     }
 
     /* ===== Wrapper cho thẻ Flashcard ===== */
@@ -161,6 +163,8 @@
         min-height: 0;
         position: relative;
         overflow: hidden;
+        max-width: 720px;
+        margin: 0 auto;
     }
 
     #flashcard-content {
@@ -175,6 +179,8 @@
         width: 100%;
         height: 100%;
         min-height: 300px;
+        max-width: 640px;
+        margin: 0 auto;
     }
 
     .flashcard-card {


### PR DESCRIPTION
## Summary
- re-tune the flashcard grid so the desktop card column is narrower and the statistics column takes more room
- cap the flashcard container widths to keep the card compact while letting the stats panel expand fully
- remove the stats card width clamp so the large-screen two-column layout can breathe without forcing scroll

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d811a6ac9483268d70d0bf322304ba